### PR TITLE
feat: add keys endpoint

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -16,6 +16,7 @@ from app.models import (  # noqa: F401
     CraftingRecipe,
     Gem,
     Grip,
+    Key,
     Material,
     MaterialRecipe,
     Spell,

--- a/alembic/versions/b2c3d4e5f6a7_add_keys_table.py
+++ b/alembic/versions/b2c3d4e5f6a7_add_keys_table.py
@@ -1,0 +1,126 @@
+"""add keys table
+
+Revision ID: b2c3d4e5f6a7
+Revises: b73583770546
+Create Date: 2026-03-20 02:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: str | Sequence[str] | None = "b73583770546"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Cross-referenced from keys.txt and keys_2.txt
+KEYS = [
+    (
+        "Bronze Key",
+        "Snowfly Forest",
+        "Return to the Land",
+        "Earth Dragon",
+        "Rue Morge (Town Center South), Shasras Hill Parks (Town Center East)",
+    ),
+    (
+        "Iron Key",
+        "Undercity East",
+        "Weapons Not Allowed",
+        "Chest",
+        "Crossroads of Rest (Undercity West), Remembering Days of Yore (Undercity West), "
+        "The Sunless Way (Undercity West), Bandits' Hallow (Abandoned Mines B2), "
+        "From Squire to Knight (Town Walls North), Noble Gold and Silk (Undercity East)",
+    ),
+    (
+        "Silver Key",
+        "Temple of Kiltia",
+        "Chapel of Meschaunce",
+        "Chest",
+        "Sewer of Ravenous Rats (Undercity West), Shelter From the Quake (Escapeway), "
+        "Everwant Passage (Abandoned Mines B1), The Washing Woman's Way (Undercity West), "
+        "The Auction Block (Limestone Quarry), Those Who Drink the Dark (Temple of Kiltia), "
+        "The Resentful Ones (Temple of Kiltia)",
+    ),
+    (
+        "Gold Key",
+        "Undercity West",
+        "Crumbling Market",
+        "Chest",
+        "The Timely Dew of Sleep (Limestone Quarry), Shelter from the Quake (Escapeway), "
+        "Tears From Empty Sockets (Undercity West), Corner of Prayers (Undercity West), "
+        "The Soldier's Bedding (Keep)",
+    ),
+    (
+        "Platinum Key",
+        "Snowfly Forest",
+        "Nature's Womb",
+        "Damascus Crab",
+        "Implement (Iron Maiden B1)",
+    ),
+    (
+        "Steel Key",
+        "Forgotten Pathway",
+        "The Fallen Knight",
+        "Chest",
+        "Hanging (Iron Maiden B1)",
+    ),
+    (
+        "Crimson Key",
+        "Town Center West",
+        "Tircolas Flow",
+        "Duane",
+        "Rue Vermilion (Town Center West)",
+    ),
+    (
+        "Chest Key",
+        "Iron Maiden B1",
+        "Spanish Tickler",
+        "Wyvern Knight",
+        "The Gallows (Wine Cellar), Hidden Resources (Abandoned Mines B2), "
+        "The Branks (Iron Maiden B1), The Warrior's Rest (Keep)",
+    ),
+    (
+        "Rood Inverse",
+        "Beat the game",
+        "",
+        "Clear Game reward",
+        "Train and Grow Strong (City Walls East), Glacialdra Kirk Ruins (Town Center West), "
+        "Crossroads of Rest (Undercity West)",
+    ),
+]
+
+
+def upgrade() -> None:
+    """Create keys table and populate with data."""
+    op.create_table(
+        "keys",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("area", sa.String(length=100), server_default="", nullable=False),
+        sa.Column("room", sa.String(length=100), server_default="", nullable=False),
+        sa.Column("source", sa.String(length=200), server_default="", nullable=False),
+        sa.Column("locations_used", sa.Text(), server_default="", nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    for name, area, room, source, locations_used in KEYS:
+        safe_name = name.replace("'", "''")
+        safe_area = area.replace("'", "''")
+        safe_room = room.replace("'", "''")
+        safe_source = source.replace("'", "''")
+        safe_locations = locations_used.replace("'", "''")
+        op.execute(
+            f"INSERT INTO keys (name, area, room, source, locations_used) "
+            f"VALUES ('{safe_name}', '{safe_area}', '{safe_room}', "
+            f"'{safe_source}', '{safe_locations}')"
+        )
+
+
+def downgrade() -> None:
+    """Drop keys table."""
+    op.drop_table("keys")

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from app.routers import (
     crafting_router,
     gems_router,
     grips_router,
+    keys_router,
     materials_router,
     spells_router,
     weapons_router,
@@ -87,6 +88,7 @@ app.include_router(gems_router)
 app.include_router(materials_router)
 app.include_router(consumables_router)
 app.include_router(spells_router)
+app.include_router(keys_router)
 app.include_router(crafting_router)
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,7 @@ from app.models.consumable import Consumable
 from app.models.crafting_recipe import CraftingRecipe, MaterialRecipe
 from app.models.gem import Gem
 from app.models.grip import Grip
+from app.models.key import Key
 from app.models.material import Material
 from app.models.spell import Spell
 from app.models.weapon import Weapon
@@ -13,6 +14,7 @@ __all__ = [
     "CraftingRecipe",
     "Gem",
     "Grip",
+    "Key",
     "Material",
     "MaterialRecipe",
     "Spell",

--- a/app/models/key.py
+++ b/app/models/key.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Key(Base):
+    __tablename__ = "keys"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    area: Mapped[str] = mapped_column(String(100), default="")
+    room: Mapped[str] = mapped_column(String(100), default="")
+    source: Mapped[str] = mapped_column(String(200), default="")
+    locations_used: Mapped[str] = mapped_column(Text, default="")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -3,6 +3,7 @@ from app.routers.consumables import router as consumables_router
 from app.routers.crafting import router as crafting_router
 from app.routers.gems import router as gems_router
 from app.routers.grips import router as grips_router
+from app.routers.keys import router as keys_router
 from app.routers.materials import router as materials_router
 from app.routers.spells import router as spells_router
 from app.routers.weapons import router as weapons_router
@@ -13,6 +14,7 @@ __all__ = [
     "crafting_router",
     "gems_router",
     "grips_router",
+    "keys_router",
     "materials_router",
     "spells_router",
     "weapons_router",

--- a/app/routers/keys.py
+++ b/app/routers/keys.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.key import Key
+from app.schemas.game_data import KeyRead
+
+router = APIRouter(prefix="/keys", tags=["keys"])
+
+
+@router.get("", response_model=list[KeyRead])
+async def list_keys(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    q: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(Key)
+    if q:
+        stmt = stmt.where(Key.name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Key.id).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{key_id}", response_model=KeyRead)
+async def get_key(key_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(Key).where(Key.id == key_id))
+    key = result.scalar_one_or_none()
+    if not key:
+        raise HTTPException(status_code=404, detail="Key not found")
+    return key

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -152,6 +152,17 @@ class SpellRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class KeyRead(BaseModel):
+    id: int
+    name: str
+    area: str = ""
+    room: str = ""
+    source: str = ""
+    locations_used: str = ""
+
+    model_config = {"from_attributes": True}
+
+
 class CraftingRecipeRead(BaseModel):
     id: int
     category: str


### PR DESCRIPTION
## Summary
- New `keys` table, model, schema, and router
- 9 keys with area, room, source, and locations_used fields
- Data cross-referenced from `keys.txt` and `keys_2.txt` game guides

## Test plan
- [ ] `GET /keys` returns all 9 keys
- [ ] `GET /keys/1` returns key detail with locations_used
- [ ] `GET /keys/999` returns 404
- [ ] Migration runs cleanly

Closes #12