### PR TITLE
feat: add sigils endpoint

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -19,6 +19,7 @@ from app.models import (  # noqa: F401
     Key,
     Material,
     MaterialRecipe,
+    Sigil,
     Spell,
     Weapon,
 )

--- a/alembic/versions/c3d4e5f6a7b8_add_sigils_table.py
+++ b/alembic/versions/c3d4e5f6a7b8_add_sigils_table.py
@@ -1,0 +1,216 @@
+"""add sigils table
+
+Revision ID: c3d4e5f6a7b8
+Revises: b73583770546
+Create Date: 2026-03-20 03:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: str | Sequence[str] | None = "b73583770546"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Cross-referenced from sigils.txt and sigils_2.txt
+SIGILS = [
+    (
+        "Acacia Sigil",
+        "Great Cathedral L1",
+        "A Light in the Dark",
+        "Arch Dragon",
+        "Hall of Broken Vows (Great Cathedral L2)",
+    ),
+    (
+        "Anemone Sigil",
+        "Iron Maiden B1",
+        "Knotting",
+        "Wyvern Queen",
+        "Urge the Boy On (The Keep)",
+    ),
+    (
+        "Aster Sigil",
+        "Undercity East",
+        "Catspaw Blackmarket",
+        "Chest",
+        "Dream of the Holy Land (Limestone Quarry)",
+    ),
+    (
+        "Azalea Sigil",
+        "Iron Maiden B2",
+        "The Shin-Vice",
+        "Ogre Zombie",
+        "Wiping Blood from Blades (The Keep)",
+    ),
+    (
+        "Calla Sigil",
+        "Great Cathedral L2",
+        "Hall of Broken Vows",
+        "Flame Dragon",
+        "Heretic''s Story (Great Cathedral L3)",
+    ),
+    (
+        "Cattleya Sigil",
+        "Undercity West",
+        "Fear of the Fall",
+        "Dark Elemental",
+        "Rue Crimnade (Town Center East)",
+    ),
+    (
+        "Chamomile Sigil",
+        "Wine Cellar",
+        "Gallows",
+        "Minotaur",
+        "Smokebarrel Stair (Wine Cellar)",
+    ),
+    (
+        "Clematis Sigil",
+        "Undercity West",
+        "Larder for a Lean Winter",
+        "Chest",
+        "Dream of the Holy Land (Limestone Quarry)",
+    ),
+    (
+        "Columbine Sigil",
+        "Iron Maiden B1",
+        "Burial",
+        "Iron Golem",
+        "A Storm of Arrows (The Keep)",
+    ),
+    (
+        "Eulalia Sigil",
+        "Undercity East",
+        "Bazaar of the Bizarre",
+        "Lich",
+        "The Dreamer''s Climb (Limestone Quarry)",
+    ),
+    (
+        "Fern Sigil",
+        "Abandoned Mines B1",
+        "Coal Mine Storage",
+        "Chest",
+        "Live Long and Prosper (Abandoned Mines B1)",
+    ),
+    (
+        "Hyacinth Sigil",
+        "Abandoned Mines B1",
+        "Battle''s Beginning",
+        "Wyvern",
+        "Earthquake''s Mark (Abandoned Mines B1)",
+    ),
+    (
+        "Kalmia Sigil",
+        "Iron Maiden B1",
+        "Starvation",
+        "Wraith",
+        "A Storm of Arrows (The Keep)",
+    ),
+    (
+        "Laurel Sigil",
+        "Great Cathedral L1",
+        "Monk''s Leap",
+        "Lich",
+        "Poisoned Chapel (Great Cathedral L1)",
+    ),
+    (
+        "Lily Sigil",
+        "Catacombs",
+        "Beast''s Domain",
+        "Lizardman",
+        "Withered Spring (Catacombs)",
+    ),
+    (
+        "Mandrake Sigil",
+        "Iron Maiden B1",
+        "The Cauldron",
+        "Wraith",
+        "Rue Aliano (Town Center South)",
+    ),
+    (
+        "Marigold Sigil",
+        "Iron Maiden B2",
+        "The Saw",
+        "Dragon Zombie",
+        "A Taste of the Spoils (The Keep)",
+    ),
+    (
+        "Melissa Sigil",
+        "Undercity East",
+        "Gemsword Blackmarket",
+        "Nightstalker",
+        "The Laborer''s Bonfire (Limestone Quarry)",
+    ),
+    (
+        "Palm Sigil",
+        "Great Cathedral L3",
+        "Hopes of the Idealist",
+        "Dao",
+        "Melodies of Madness (Great Cathedral L2)",
+    ),
+    (
+        "Schirra Sigil",
+        "Iron Maiden B2",
+        "Pressing",
+        "Ravana",
+        "A Taste of the Spoils (The Keep)",
+    ),
+    (
+        "Stock Sigil",
+        "Undercity East",
+        "Sale of the Sword",
+        "Chest",
+        "Blackmarket of Wines (Wine Cellar)",
+    ),
+    (
+        "Tearose Sigil",
+        "Abandoned Mines B2",
+        "Dining in Darkness",
+        "Sky Dragon",
+        "The Cauldron (Iron Maiden B1)",
+    ),
+    (
+        "Tigertail Sigil",
+        "Iron Maiden B3",
+        "The Iron Maiden",
+        "Asura",
+        "Wiping Blood from Blades (The Keep)",
+    ),
+    (
+        "Verbena Sigil",
+        "Iron Maiden B2",
+        "Ordeal by Fire",
+        "Dark Dragon",
+        "Urge the Boy On (The Keep)",
+    ),
+]
+
+
+def upgrade() -> None:
+    """Create sigils table and populate with data."""
+    op.create_table(
+        "sigils",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("area", sa.String(length=100), server_default="", nullable=False),
+        sa.Column("room", sa.String(length=100), server_default="", nullable=False),
+        sa.Column("source", sa.String(length=200), server_default="", nullable=False),
+        sa.Column("door_unlocks", sa.Text(), server_default="", nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    for name, area, room, source, door_unlocks in SIGILS:
+        op.execute(
+            f"INSERT INTO sigils (name, area, room, source, door_unlocks) "
+            f"VALUES ('{name}', '{area}', '{room}', '{source}', '{door_unlocks}')"
+        )
+
+
+def downgrade() -> None:
+    """Drop sigils table."""
+    op.drop_table("sigils")

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.routers import (
     grips_router,
     keys_router,
     materials_router,
+    sigils_router,
     spells_router,
     weapons_router,
 )
@@ -87,6 +88,7 @@ app.include_router(armor_router)
 app.include_router(gems_router)
 app.include_router(materials_router)
 app.include_router(consumables_router)
+app.include_router(sigils_router)
 app.include_router(spells_router)
 app.include_router(keys_router)
 app.include_router(crafting_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.gem import Gem
 from app.models.grip import Grip
 from app.models.key import Key
 from app.models.material import Material
+from app.models.sigil import Sigil
 from app.models.spell import Spell
 from app.models.weapon import Weapon
 
@@ -17,6 +18,7 @@ __all__ = [
     "Key",
     "Material",
     "MaterialRecipe",
+    "Sigil",
     "Spell",
     "Weapon",
 ]

--- a/app/models/sigil.py
+++ b/app/models/sigil.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Sigil(Base):
+    __tablename__ = "sigils"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    area: Mapped[str] = mapped_column(String(100), default="")
+    room: Mapped[str] = mapped_column(String(100), default="")
+    source: Mapped[str] = mapped_column(String(200), default="")
+    door_unlocks: Mapped[str] = mapped_column(Text, default="")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -5,6 +5,7 @@ from app.routers.gems import router as gems_router
 from app.routers.grips import router as grips_router
 from app.routers.keys import router as keys_router
 from app.routers.materials import router as materials_router
+from app.routers.sigils import router as sigils_router
 from app.routers.spells import router as spells_router
 from app.routers.weapons import router as weapons_router
 
@@ -16,6 +17,7 @@ __all__ = [
     "grips_router",
     "keys_router",
     "materials_router",
+    "sigils_router",
     "spells_router",
     "weapons_router",
 ]

--- a/app/routers/sigils.py
+++ b/app/routers/sigils.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.sigil import Sigil
+from app.schemas.game_data import SigilRead
+
+router = APIRouter(prefix="/sigils", tags=["sigils"])
+
+
+@router.get("", response_model=list[SigilRead])
+async def list_sigils(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    q: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(Sigil)
+    if q:
+        stmt = stmt.where(Sigil.name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Sigil.id).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{sigil_id}", response_model=SigilRead)
+async def get_sigil(sigil_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(Sigil).where(Sigil.id == sigil_id))
+    sigil = result.scalar_one_or_none()
+    if not sigil:
+        raise HTTPException(status_code=404, detail="Sigil not found")
+    return sigil

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -163,6 +163,17 @@ class KeyRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class SigilRead(BaseModel):
+    id: int
+    name: str
+    area: str = ""
+    room: str = ""
+    source: str = ""
+    door_unlocks: str = ""
+
+    model_config = {"from_attributes": True}
+
+
 class CraftingRecipeRead(BaseModel):
     id: int
     category: str


### PR DESCRIPTION
## Summary
- New `sigils` table, model, schema, and router
- 24 sigils with area, room, source, and door_unlocks fields
- Data cross-referenced from `sigils.txt` and `sigils_2.txt` game guides

## Test plan
- [ ] `GET /sigils` returns all 24 sigils
- [ ] `GET /sigils/1` returns sigil detail with door_unlocks
- [ ] `GET /sigils/999` returns 404

Closes #13