### PR TITLE
feat: add grimoires endpoint

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -15,6 +15,7 @@ from app.models import (  # noqa: F401
     Consumable,
     CraftingRecipe,
     Gem,
+    Grimoire,
     Grip,
     Key,
     Material,

--- a/alembic/versions/d4e5f6a7b8c9_add_grimoires_table.py
+++ b/alembic/versions/d4e5f6a7b8c9_add_grimoires_table.py
@@ -1,0 +1,240 @@
+"""add grimoires table
+
+Revision ID: d4e5f6a7b8c9
+Revises: b73583770546
+Create Date: 2026-03-20 04:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: str | Sequence[str] | None = "b73583770546"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Data from grimoires_2.txt - each source is a separate entry
+# (name, spell_name, area, room, source, drop_rate, repeatable)
+GRIMOIRES = [
+    ("Agilite", "Invigorate", "Snowfly Forest", "Forest River", "Chest", "", False),
+    ("Ameliorer", "Prostasia", "Sanctum", "Hall of Sacrilege", "Golem", "", False),
+    ("Analyse", "Analyze", "Sanctum", "The Cleansing Chantry", "Dragon", "", False),
+    ("Annuler", "Magic Ward", "Snowfly Forest", "Hewn from Nature", "Grissom", "", False),
+    ("Antidote", "Antidote", "Catacombs", "The Beast''s Domain", "Lizardman", "", False),
+    ("Avalanche", "Avalanche", "Great Cathedral B1", "Order and Chaos", "Marid", "", False),
+    (
+        "Avalanche",
+        "Avalanche",
+        "Limestone Quarry",
+        "Dream of the Holy Land",
+        "Water Elemental",
+        "",
+        False,
+    ),
+    ("Avalanche", "Avalanche", "Escapeway", "Fear and Loathing", "Marid", "", False),
+    (
+        "Avalanche",
+        "Avalanche",
+        "Temple of Kiltia",
+        "Hall of Prayer",
+        "Water Elemental",
+        "8/255",
+        True,
+    ),
+    ("Avalanche", "Avalanche", "Iron Maiden B1", "The Ducking Stool", "Shadow", "8/255", True),
+    ("Banish", "Banish", "Undercity East", "Arms Against Invaders", "Harpy", "13/255", True),
+    (
+        "Barrer",
+        "Aqua Guard",
+        "Limestone Quarry",
+        "Hall of the Wage-Paying",
+        "Snow Dragon",
+        "",
+        False,
+    ),
+    ("Benir", "Blessing", "Limestone Quarry", "Bonds of Friendship", "Chest", "", False),
+    ("Clef", "Unlock", "Town Center West", "Tircolas Flow", "Duane", "", False),
+    ("Debile", "Degenerate", "Wine Cellar", "The Gallows", "Minotaur", "", False),
+    ("Demance", "Drain Mind", "Abandoned Mines B2", "Dining in Darkness", "Sky Dragon", "", False),
+    ("Demolir", "Explosion", "Great Cathedral L1", "Monk''s Leap", "Lich", "", False),
+    ("Demolir", "Explosion", "Town Center West", "Tircolas Flow", "Duane", "", False),
+    ("Demolir", "Explosion", "Undercity East", "Where Black Waters Ran", "Lich", "8/255", True),
+    ("Deteriorer", "Tarnish", "Snowfly Forest", "Hewn from Nature", "Dark Crusader", "", False),
+    ("Dissiper", "Dispel", "Undercity West", "The Children''s Hideout", "Chest", "", False),
+    ("Eclairer", "Enlighten", "Undercity East", "Gemsword Blackmarket", "Nightstalker", "", False),
+    ("Egout", "Drain Heart", "Limestone Quarry", "Stone and Sulfurous Fire", "Chest", "", False),
+    ("Exsorcer", "Exorcism", "Iron Maiden B1", "The Cauldron", "Wraith", "", False),
+    ("Flamme", "Flame Sphere", "Great Cathedral B1", "Truth and Lies", "Ifrit", "", False),
+    ("Flamme", "Flame Sphere", "Abandoned Mines B1", "The Smeltry", "Fire Elemental", "", False),
+    ("Flamme", "Flame Sphere", "Escapeway", "Fear and Loathing", "Ifrit", "", False),
+    ("Flamme", "Flame Sphere", "Limestone Quarry", "Excavated Hollow", "Chest", "", False),
+    ("Flamme", "Flame Sphere", "Iron Maiden B1", "The Judas Cradle", "Shadow", "8/255", True),
+    ("Fleau", "Curse", "Limestone Quarry", "Companions in Arms", "Chest", "", False),
+    ("Foudre", "Thunderburst", "Great Cathedral L1", "The Flayed Confessional", "Djinn", "", False),
+    (
+        "Foudre",
+        "Thunderburst",
+        "Abandoned Mines B2",
+        "The Miner''s End",
+        "Air Elemental",
+        "",
+        False,
+    ),
+    (
+        "Foudre",
+        "Thunderburst",
+        "Temple of Kiltia",
+        "Those who Fear the Light",
+        "Air Elemental",
+        "8/255",
+        True,
+    ),
+    ("Foudre", "Thunderburst", "Iron Maiden B1", "The Branks", "Shadow", "8/255", True),
+    ("Gaea", "Gaea Strike", "Great Cathedral L3", "Hopes of the Idealist", "Dao", "", False),
+    (
+        "Gaea",
+        "Gaea Strike",
+        "Abandoned Mines B2",
+        "Tomb of the Reborn",
+        "Earth Elemental",
+        "",
+        False,
+    ),
+    ("Gaea", "Gaea Strike", "Iron Maiden B1", "The Wheel", "Shadow", "8/255", True),
+    ("Glace", "Aqua Blast", "Sanctum", "Theology Classroom", "Ghost", "8/255", True),
+    (
+        "Glace",
+        "Aqua Blast",
+        "Undercity West",
+        "Remembering Days of Yore",
+        "Zombie Mage",
+        "8/255",
+        True,
+    ),
+    ("Glace", "Aqua Blast", "Undercity West", "Corner of Prayers", "Dark Eye", "8/255", True),
+    ("Gnome", "Soil Fusion", "Snowfly Forest", "Hewn from Nature", "Grissom", "", False),
+    ("Guerir", "Heal", "Wine Cellar", "The Gallows", "Minotaur", "", False),
+    ("Halte", "Fixate", "Sanctum", "Alchemists'' Laboratory", "Chest", "", False),
+    (
+        "Ignifuge",
+        "Pyro Guard",
+        "Abandoned Mines B1",
+        "The Battle''s Beginning",
+        "Wyvern",
+        "",
+        False,
+    ),
+    ("Incendie", "Fireball", "Catacombs", "Bandits'' Hideout", "Ghost", "8/255", True),
+    (
+        "Incendie",
+        "Fireball",
+        "Undercity West",
+        "Sewer of Ravenous Rats",
+        "Zombie Mage",
+        "8/255",
+        True,
+    ),
+    ("Incendie", "Fireball", "Undercity West", "Nameless Dark Oblivion", "Dark Eye", "8/255", True),
+    ("Intensite", "Herakles", "Undercity East", "Place of Free Words", "Harpy", "", False),
+    ("Lux", "Spirit Surge", "Wine Cellar", "The Hero''s Winehall", "Dullahan", "", False),
+    ("Lux", "Spirit Surge", "Iron Maiden B1", "The Cauldron", "Wraith", "8/255", True),
+    ("Meteore", "Meteor", "Great Cathedral L2", "What Ails You, Kills You", "Nightmare", "", False),
+    ("Meteore", "Meteor", "Undercity West", "Fear of the Fall", "Dark Elemental", "", False),
+    ("Meteore", "Meteor", "Undercity East", "Catspaw Blackmarket", "Lich", "8/255", True),
+    ("Meteore", "Meteor", "Escapeway", "Buried Alive", "Chest", "", False),
+    ("Mollesse", "Restoration", "Abandoned Mines B2", "Hidden Resources", "Chest", "", False),
+    ("Muet", "Silence", "Town Center South", "The House Khazabas", "Chest", "", False),
+    ("Nuageux", "Psychodrain", "Undercity East", "Weapons Not Allowed", "Chest", "", False),
+    ("Paralysie", "Stun Cloud", "Undercity East", "Catspaw Blackmarket", "Chest", "", False),
+    ("Parebrise", "Aero Guard", "Snowfly Forest", "Return to the Land", "Earth Dragon", "", False),
+    ("Patir", "Dark Chant", "Undercity West", "Sinner''s Corner", "Dark Eye", "8/255", True),
+    ("Patir", "Dark Chant", "Iron Maiden B1", "The Cauldron", "Wraith", "8/255", True),
+    ("Purifier", "Clearance", "Temple of Kiltia", "Hall of Prayer", "Last Crusader", "", False),
+    ("Radius", "Radial Surge", "Great Cathedral L2", "Maelstrom of Malice", "Lich Lord", "", False),
+    ("Radius", "Radial Surge", "Undercity East", "Sale of the Sword", "Lich", "13/255", True),
+    ("Radius", "Radial Surge", "Undercity East", "Weapons Not Allowed", "Lich", "13/255", True),
+    ("Radius", "Radial Surge", "Escapeway", "Buried Alive", "Chest", "", False),
+    ("Rempart", "Terra Guard", "Abandoned Mines B1", "Traitor''s Parting", "Ogre", "", False),
+    (
+        "Salamandre",
+        "Spark Fusion",
+        "Abandoned Mines B2",
+        "Delusions of Happiness",
+        "Chest",
+        "",
+        False,
+    ),
+    ("Sylphe", "Luft Fusion", "Undercity West", "Underdark Fishmarket", "Giant Crab", "", False),
+    ("Tardif", "Leadbones", "Undercity East", "Sale of the Sword", "Chest", "", False),
+    ("Terre", "Vulcan Lance", "Catacombs", "The Withered Spring", "Ghost", "8/255", True),
+    (
+        "Terre",
+        "Vulcan Lance",
+        "Undercity West",
+        "The Washing-Woman''s Way",
+        "Zombie Mage",
+        "8/255",
+        True,
+    ),
+    (
+        "Terre",
+        "Vulcan Lance",
+        "Undercity West",
+        "The Children''s Hideout",
+        "Dark Eye",
+        "8/255",
+        True,
+    ),
+    ("Teslae", "Lightning Bolt", "Catacombs", "Rodent-Ridden Chamber", "Ghost", "8/255", True),
+    (
+        "Teslae",
+        "Lightning Bolt",
+        "Undercity West",
+        "Underdark Fishmarket",
+        "Zombie Mage",
+        "8/255",
+        True,
+    ),
+    ("Teslae", "Lightning Bolt", "Undercity West", "Fear of the Fall", "Dark Eye", "8/255", True),
+    ("Undine", "Frost Fusion", "Abandoned Mines B1", "Rust in Peace", "Chest", "", False),
+    ("Venin", "Poison Mist", "Iron Maiden B1", "Starvation", "Wraith", "", False),
+    ("Vie", "Surging Balm", "Abandoned Mines B2", "Acolyte''s Burial Vault", "Chest", "", False),
+    ("Visible", "Eureka", "Abandoned Mines B1", "Miners'' Resting Hall", "Chest", "", False),
+    ("Zephyr", "Solid Shock", "Catacombs", "The Lamenting Mother", "Ghost", "8/255", True),
+    ("Zephyr", "Solid Shock", "Undercity West", "Corner of Prayers", "Dark Eye", "8/255", True),
+    ("Zephyr", "Solid Shock", "Iron Maiden B1", "Starvation", "Wraith", "8/255", True),
+]
+
+
+def upgrade() -> None:
+    """Create grimoires table and populate with data."""
+    op.create_table(
+        "grimoires",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("spell_name", sa.String(length=100), server_default="", nullable=False),
+        sa.Column("area", sa.String(length=100), server_default="", nullable=False),
+        sa.Column("room", sa.String(length=200), server_default="", nullable=False),
+        sa.Column("source", sa.String(length=200), server_default="", nullable=False),
+        sa.Column("drop_rate", sa.String(length=50), server_default="", nullable=False),
+        sa.Column("repeatable", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    for name, spell_name, area, room, source, drop_rate, repeatable in GRIMOIRES:
+        rep = "true" if repeatable else "false"
+        op.execute(
+            f"INSERT INTO grimoires (name, spell_name, area, room, source, drop_rate, repeatable) "
+            f"VALUES ('{name}', '{spell_name}', '{area}', '{room}', "
+            f"'{source}', '{drop_rate}', {rep})"
+        )
+
+
+def downgrade() -> None:
+    """Drop grimoires table."""
+    op.drop_table("grimoires")

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from app.routers import (
     consumables_router,
     crafting_router,
     gems_router,
+    grimoires_router,
     grips_router,
     keys_router,
     materials_router,
@@ -91,6 +92,7 @@ app.include_router(consumables_router)
 app.include_router(sigils_router)
 app.include_router(spells_router)
 app.include_router(keys_router)
+app.include_router(grimoires_router)
 app.include_router(crafting_router)
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,7 @@ from app.models.armor import Armor
 from app.models.consumable import Consumable
 from app.models.crafting_recipe import CraftingRecipe, MaterialRecipe
 from app.models.gem import Gem
+from app.models.grimoire import Grimoire
 from app.models.grip import Grip
 from app.models.key import Key
 from app.models.material import Material
@@ -14,6 +15,7 @@ __all__ = [
     "Consumable",
     "CraftingRecipe",
     "Gem",
+    "Grimoire",
     "Grip",
     "Key",
     "Material",

--- a/app/models/grimoire.py
+++ b/app/models/grimoire.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Boolean, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Grimoire(Base):
+    __tablename__ = "grimoires"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    spell_name: Mapped[str] = mapped_column(String(100), default="")
+    area: Mapped[str] = mapped_column(String(100), default="")
+    room: Mapped[str] = mapped_column(String(200), default="")
+    source: Mapped[str] = mapped_column(String(200), default="")
+    drop_rate: Mapped[str] = mapped_column(String(50), default="")
+    repeatable: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -2,6 +2,7 @@ from app.routers.armor import router as armor_router
 from app.routers.consumables import router as consumables_router
 from app.routers.crafting import router as crafting_router
 from app.routers.gems import router as gems_router
+from app.routers.grimoires import router as grimoires_router
 from app.routers.grips import router as grips_router
 from app.routers.keys import router as keys_router
 from app.routers.materials import router as materials_router
@@ -14,6 +15,7 @@ __all__ = [
     "consumables_router",
     "crafting_router",
     "gems_router",
+    "grimoires_router",
     "grips_router",
     "keys_router",
     "materials_router",

--- a/app/routers/grimoires.py
+++ b/app/routers/grimoires.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.grimoire import Grimoire
+from app.schemas.game_data import GrimoireRead
+
+router = APIRouter(prefix="/grimoires", tags=["grimoires"])
+
+
+@router.get("", response_model=list[GrimoireRead])
+async def list_grimoires(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(200, ge=1, le=500),
+    q: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(Grimoire)
+    if q:
+        stmt = stmt.where(Grimoire.name.ilike(f"%{q}%") | Grimoire.spell_name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Grimoire.name, Grimoire.id).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{grimoire_id}", response_model=GrimoireRead)
+async def get_grimoire(grimoire_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(Grimoire).where(Grimoire.id == grimoire_id))
+    grimoire = result.scalar_one_or_none()
+    if not grimoire:
+        raise HTTPException(status_code=404, detail="Grimoire not found")
+    return grimoire

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -174,6 +174,19 @@ class SigilRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class GrimoireRead(BaseModel):
+    id: int
+    name: str
+    spell_name: str = ""
+    area: str = ""
+    room: str = ""
+    source: str = ""
+    drop_rate: str = ""
+    repeatable: bool = False
+
+    model_config = {"from_attributes": True}
+
+
 class CraftingRecipeRead(BaseModel):
     id: int
     category: str


### PR DESCRIPTION
## Summary
- New `grimoires` table, model, schema, and router
- 83 entries (one per drop source) with spell name, area, room, source, drop rate, and repeatability
- Data parsed from `grimoires_2.txt` game guide
- Search works across both grimoire name and spell name

## Test plan
- [ ] `GET /grimoires` returns all entries
- [ ] `GET /grimoires?q=fireball` searches spell names
- [ ] `GET /grimoires/1` returns grimoire detail
- [ ] `GET /grimoires/999` returns 404

Closes #14