### PR TITLE
feat: add workshops endpoint

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -23,6 +23,7 @@ from app.models import (  # noqa: F401
     Sigil,
     Spell,
     Weapon,
+    Workshop,
 )
 
 # this is the Alembic Config object, which provides

--- a/alembic/versions/e5f6a7b8c9d0_add_workshops_table.py
+++ b/alembic/versions/e5f6a7b8c9d0_add_workshops_table.py
@@ -1,0 +1,88 @@
+"""add workshops table
+
+Revision ID: e5f6a7b8c9d0
+Revises: b73583770546
+Create Date: 2026-03-20 05:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e5f6a7b8c9d0"
+down_revision: str | Sequence[str] | None = "b73583770546"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Data from workshops.txt
+WORKSHOPS = [
+    (
+        "Work of Art",
+        "Catacombs: Withered Spring",
+        "Wood, Leather, Bronze",
+        "The first workshop encountered. Limited to basic materials.",
+    ),
+    (
+        "The Magic Hammer",
+        "Town Center West: Rene Coast Road",
+        "Bronze, Iron",
+        "Second workshop with access to Iron-tier crafting.",
+    ),
+    (
+        "Keane''s Crafts",
+        "The Keep: The Warrior''s Rest",
+        "Bronze, Iron, Hagane",
+        "Mid-game workshop with Hagane material support.",
+    ),
+    (
+        "Junction Point",
+        "Town Center East: Rue Crimnade",
+        "Wood, Leather, Bronze, Iron, Hagane",
+        "Accessible after obtaining the Cattleya Sigil. Wide material range.",
+    ),
+    (
+        "Metal Works",
+        "Town Center East: Rue Fisserano",
+        "Silver, Damascus",
+        "Late-game workshop specializing in rare metals.",
+    ),
+    (
+        "Godhands",
+        "Undercity West: Bite The Master''s Wounds",
+        "Wood, Leather, Bronze, Hagane, Silver, Damascus",
+        "The ultimate workshop available only in New Game Plus. Supports all materials.",
+    ),
+]
+
+
+def upgrade() -> None:
+    """Create workshops table and populate with data."""
+    op.create_table(
+        "workshops",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("area", sa.String(length=200), server_default="", nullable=False),
+        sa.Column(
+            "available_materials",
+            sa.String(length=300),
+            server_default="",
+            nullable=False,
+        ),
+        sa.Column("description", sa.Text(), server_default="", nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    for name, area, materials, description in WORKSHOPS:
+        op.execute(
+            f"INSERT INTO workshops (name, area, available_materials, description) "
+            f"VALUES ('{name}', '{area}', '{materials}', '{description}')"
+        )
+
+
+def downgrade() -> None:
+    """Drop workshops table."""
+    op.drop_table("workshops")

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from app.routers import (
     sigils_router,
     spells_router,
     weapons_router,
+    workshops_router,
 )
 
 setup_logging()
@@ -93,6 +94,7 @@ app.include_router(sigils_router)
 app.include_router(spells_router)
 app.include_router(keys_router)
 app.include_router(grimoires_router)
+app.include_router(workshops_router)
 app.include_router(crafting_router)
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.material import Material
 from app.models.sigil import Sigil
 from app.models.spell import Spell
 from app.models.weapon import Weapon
+from app.models.workshop import Workshop
 
 __all__ = [
     "Armor",
@@ -23,4 +24,5 @@ __all__ = [
     "Sigil",
     "Spell",
     "Weapon",
+    "Workshop",
 ]

--- a/app/models/workshop.py
+++ b/app/models/workshop.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Workshop(Base):
+    __tablename__ = "workshops"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    area: Mapped[str] = mapped_column(String(200), default="")
+    available_materials: Mapped[str] = mapped_column(String(300), default="")
+    description: Mapped[str] = mapped_column(Text, default="")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -9,6 +9,7 @@ from app.routers.materials import router as materials_router
 from app.routers.sigils import router as sigils_router
 from app.routers.spells import router as spells_router
 from app.routers.weapons import router as weapons_router
+from app.routers.workshops import router as workshops_router
 
 __all__ = [
     "armor_router",
@@ -22,4 +23,5 @@ __all__ = [
     "sigils_router",
     "spells_router",
     "weapons_router",
+    "workshops_router",
 ]

--- a/app/routers/workshops.py
+++ b/app/routers/workshops.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.workshop import Workshop
+from app.schemas.game_data import WorkshopRead
+
+router = APIRouter(prefix="/workshops", tags=["workshops"])
+
+
+@router.get("", response_model=list[WorkshopRead])
+async def list_workshops(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    q: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(Workshop)
+    if q:
+        stmt = stmt.where(Workshop.name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Workshop.id).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{workshop_id}", response_model=WorkshopRead)
+async def get_workshop(workshop_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(Workshop).where(Workshop.id == workshop_id))
+    workshop = result.scalar_one_or_none()
+    if not workshop:
+        raise HTTPException(status_code=404, detail="Workshop not found")
+    return workshop

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -187,6 +187,16 @@ class GrimoireRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class WorkshopRead(BaseModel):
+    id: int
+    name: str
+    area: str = ""
+    available_materials: str = ""
+    description: str = ""
+
+    model_config = {"from_attributes": True}
+
+
 class CraftingRecipeRead(BaseModel):
     id: int
     category: str


### PR DESCRIPTION
## Summary
- New `workshops` table, model, schema, and router
- 6 workshops with name, area/location, available materials, and description
- Data parsed from `workshops.txt` game guide

## Test plan
- [ ] `GET /workshops` returns all 6 workshops
- [ ] `GET /workshops/1` returns workshop detail
- [ ] `GET /workshops/999` returns 404

Closes #10