### PR TITLE
Add break arts and battle abilities

### DIFF
--- a/alembic/versions/a2b3c4d5e6f7_add_break_arts_table.py
+++ b/alembic/versions/a2b3c4d5e6f7_add_break_arts_table.py
@@ -1,0 +1,114 @@
+"""add break_arts table
+
+Revision ID: a2b3c4d5e6f7
+Revises: d298371e8ad0
+Create Date: 2026-03-21 01:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a2b3c4d5e6f7"
+down_revision: str | Sequence[str] | None = "d298371e8ad0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (name, weapon_type, hp_cost, attack_multiplier, damage_type, affinity, special_effect, kills_required)
+BREAK_ARTS = [
+    # Dagger
+    ("Whistle Sting", "Dagger", 25, "1.1", "Blunt", "As weapon", None, 10),
+    ("Shadoweave", "Dagger", 40, "1.2", "Blunt", "Dark", "Paralysis", 65),
+    ("Double Fang", "Dagger", 55, "1.2+1.0", "Piercing", "As weapon", "Two hits", 175),
+    ("Wyrm Scorn", "Dagger", 75, "1.3", "Piercing", "As weapon", None, 340),
+    # Sword
+    ("Rending Gale", "Sword", 25, "1.1", "Piercing", "As weapon", None, 20),
+    ("Vile Scar", "Sword", 40, "1.2", "Edged", "As weapon", "Poison", 90),
+    ("Cherry Ronde", "Sword", 55, "1.2", "Edged", "Water", None, 235),
+    ("Papillon Reel", "Sword", 75, "1.3", "Edged", "Light", None, 425),
+    # Great Sword
+    ("Sunder", "Great Sword", 25, "1.1", "Piercing", "As weapon", None, 25),
+    ("Thunderwave", "Great Sword", 40, "1.2", "Edged", "Air", "Paralysis", 110),
+    ("Swallow Slash", "Great Sword", 55, "1.2+1.0", "Edged", "As weapon", "Two hits", 260),
+    ("Advent Sign", "Great Sword", 75, "1.3", "Edged", "Light", None, 485),
+    # Axe/Mace
+    ("Mistral Edge", "Axe/Mace", 25, "1.1", "Blunt", "As weapon", None, 18),
+    ("Glacial Gale", "Axe/Mace", 40, "1.2", "Blunt", "Air", "Numbness", 80),
+    ("Killer Mantis", "Axe/Mace", 55, "1.2+1.5", "Edged", "As weapon", "MP drain (INT)", 210),
+    ("Black Nebula", "Axe/Mace", 75, "1.3", "Blunt", "Dark", None, 420),
+    # Great Axe
+    ("Bear Claw", "Great Axe", 25, "1.1", "Blunt", "As weapon", None, 20),
+    ("Accursed Umbra", "Great Axe", 40, "1.2", "Blunt", "As weapon", "Curse", 100),
+    ("Iron Ripper", "Great Axe", 55, "1.2", "Blunt", "As weapon", "Damages armor", 245),
+    ("Emetic Bomb", "Great Axe", 75, "1.3", "Edged", "As weapon", None, 465),
+    # Staff
+    ("Sirocco", "Staff", 25, "1.1", "Blunt", "Fire", None, 15),
+    ("Riskbreak", "Staff", 40, "1.2", "Piercing", "As weapon", "Cancels RISK", 90),
+    ("Gravis Aether", "Staff", 55, "1.2", "Blunt", "Earth", None, 215),
+    ("Trinity Pulse", "Staff", 75, "1.3", "Blunt", "As weapon", None, 410),
+    # Heavy Mace
+    ("Bonecrusher", "Heavy Mace", 25, "1.1", "Blunt", "As weapon", None, 20),
+    ("Quickshock", "Heavy Mace", 40, "1.2", "Blunt", "Air", "Numbness", 95),
+    ("Ignis Wheel", "Heavy Mace", 55, "1.2+1.0", "Blunt", "As weapon+Fire", "Two hits", 205),
+    ("Hex Flux", "Heavy Mace", 75, "1.3+1.0", "Blunt", "Light+Dark", "Two hits", 385),
+    # Polearm
+    ("Ruination", "Polearm", 25, "1.1", "Piercing", "As weapon", None, 15),
+    ("Scythe Wind", "Polearm", 40, "1.2", "Piercing", "Air", "Tarnish", 95),
+    ("Giga Tempest", "Polearm", 55, "1.2", "Piercing", "As weapon", "Damages armor", 220),
+    ("Spiral Scourge", "Polearm", 75, "1.3", "Piercing", "Water", None, 405),
+    # Crossbow
+    ("Brimstone Hail", "Crossbow", 25, "1.1+1.0", "Piercing", "Dark+Fire", "Two hits", 20),
+    ("Heaven's Scorn", "Crossbow", 40, "1.2+1.0", "Piercing", "Light+Air", "Two hits", 95),
+    ("Death Wail", "Crossbow", 55, "1.2+1.0", "Piercing", "Dark+Earth", "Two hits", 230),
+    ("Sanctus Flare", "Crossbow", 75, "1.3+1.0", "Piercing", "Light+Water", "Two hits", 430),
+    # Bare Hands
+    ("Lotus Palm", "Bare Hands", 25, "1.2", "Blunt", "Physical", None, 30),
+    ("Vertigo", "Bare Hands", 40, "1.3", "Blunt", "Physical", "Numbness", 105),
+    ("Vermillion Aura", "Bare Hands", 55, "1.3+1.0", "Blunt", "Light", "Two hits", 250),
+    ("Retribution", "Bare Hands", 75, "1.5", "Blunt", "Dark", None, 460),
+]
+
+
+def upgrade() -> None:
+    """Create break_arts table and populate with data."""
+    op.create_table(
+        "break_arts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("weapon_type", sa.String(length=50), nullable=False),
+        sa.Column("hp_cost", sa.Integer(), nullable=False),
+        sa.Column("attack_multiplier", sa.String(length=20), nullable=False),
+        sa.Column("damage_type", sa.String(length=20), nullable=False),
+        sa.Column("affinity", sa.String(length=50), nullable=False),
+        sa.Column("special_effect", sa.String(length=100), nullable=True),
+        sa.Column("kills_required", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    for (
+        name,
+        weapon_type,
+        hp_cost,
+        attack_multiplier,
+        damage_type,
+        affinity,
+        special_effect,
+        kills_required,
+    ) in BREAK_ARTS:
+        safe_name = name.replace("'", "''")
+        special_sql = f"'{special_effect}'" if special_effect else "NULL"
+        op.execute(
+            f"INSERT INTO break_arts (name, weapon_type, hp_cost, attack_multiplier, "
+            f"damage_type, affinity, special_effect, kills_required) "
+            f"VALUES ('{safe_name}', '{weapon_type}', {hp_cost}, '{attack_multiplier}', "
+            f"'{damage_type}', '{affinity}', {special_sql}, {kills_required})"
+        )
+
+
+def downgrade() -> None:
+    """Drop break_arts table."""
+    op.drop_table("break_arts")

--- a/alembic/versions/b3c4d5e6f7a8_add_battle_abilities_table.py
+++ b/alembic/versions/b3c4d5e6f7a8_add_battle_abilities_table.py
@@ -1,0 +1,82 @@
+"""add battle_abilities table
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-03-21 01:01:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3c4d5e6f7a8"
+down_revision: str | Sequence[str] | None = "a2b3c4d5e6f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (name, ability_type, risk_cost, effect, power)
+BATTLE_ABILITIES = [
+    # Chain abilities (14)
+    ("Crimson Pain", "Chain", 2, "HP Damage + self-damage", "100% + 30% self"),
+    ("Dulling Impact", "Chain", 3, "Silence", "No damage"),
+    ("Gain Life", "Chain", 2, "Restore HP (self)", "30% of hit"),
+    ("Gain Magic", "Chain", 2, "Restore MP (self)", "30% of hit"),
+    ("Heavy Shot", "Chain", 1, "HP Damage", "70% of hit"),
+    ("Instill", "Chain", 1, "HP Damage + restore weapon PP", "10% + 100% PP"),
+    ("Mind Ache", "Chain", 1, "MP Damage", "20% of MP lost"),
+    ("Mind Assault", "Chain", 1, "MP Damage", "30% of hit"),
+    ("Numbing Claw", "Chain", 3, "Numbness", "No damage"),
+    ("Paralysis Pulse", "Chain", 3, "Paralysis", "No damage"),
+    ("Phantom Pain", "Chain", 3, "HP Damage (weapon PP) + consume PP", "Current PP"),
+    ("Raging Ache", "Chain", 1, "HP Damage", "10% of HP lost"),
+    ("Snake Venom", "Chain", 3, "Poison", "No damage"),
+    ("Temper", "Chain", 2, "HP Damage + restore weapon DP", "40% + 200% DP"),
+    # Defense abilities (14)
+    ("Absorb Damage", "Defense", 4, "Heal from physical damage", "20% of damage"),
+    ("Absorb Magic", "Defense", 4, "Heal from magic damage", "20% of damage"),
+    ("Aqua Ward", "Defense", 4, "Heal from water damage", "50% of damage"),
+    ("Demonscale", "Defense", 4, "Heal from dark damage", "50% of damage"),
+    ("Fireproof", "Defense", 4, "Heal from fire damage", "50% of damage"),
+    ("Impact Guard", "Defense", 4, "Heal from physical damage", "50% of damage"),
+    ("Phantom Shield", "Defense", 6, "Heal from any damage + consume shield PP", "Current PP"),
+    ("Reflect Damage", "Defense", 2, "Reflect physical damage", "40% of damage"),
+    ("Reflect Magic", "Defense", 2, "Reflect magic damage", "40% of damage"),
+    ("Shadow Guard", "Defense", 4, "Heal from light damage", "50% of damage"),
+    ("Siphon Soul", "Defense", 6, "Restore MP from spells", "50% of MP used"),
+    ("Terra Ward", "Defense", 4, "Heal from earth damage", "50% of damage"),
+    ("Ward", "Defense", 1, "Cure Paralysis + Numbness", "No damage"),
+    ("Windbreak", "Defense", 4, "Heal from air damage", "50% of damage"),
+]
+
+
+def upgrade() -> None:
+    """Create battle_abilities table and populate with data."""
+    op.create_table(
+        "battle_abilities",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("ability_type", sa.String(length=20), nullable=False),
+        sa.Column("risk_cost", sa.Integer(), nullable=False),
+        sa.Column("effect", sa.String(length=200), nullable=False),
+        sa.Column("power", sa.String(length=100), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    for name, ability_type, risk_cost, effect, power in BATTLE_ABILITIES:
+        safe_name = name.replace("'", "''")
+        safe_effect = effect.replace("'", "''")
+        safe_power = power.replace("'", "''")
+        op.execute(
+            f"INSERT INTO battle_abilities (name, ability_type, risk_cost, effect, power) "
+            f"VALUES ('{safe_name}', '{ability_type}', {risk_cost}, "
+            f"'{safe_effect}', '{safe_power}')"
+        )
+
+
+def downgrade() -> None:
+    """Drop battle_abilities table."""
+    op.drop_table("battle_abilities")

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,9 @@ from app.config import settings
 from app.logging import setup_logging
 from app.routers import (
     armor_router,
+    battle_abilities_router,
     blades_router,
+    break_arts_router,
     consumables_router,
     crafting_router,
     gems_router,
@@ -93,6 +95,8 @@ app.include_router(armor_router)
 app.include_router(gems_router)
 app.include_router(materials_router)
 app.include_router(consumables_router)
+app.include_router(break_arts_router)
+app.include_router(battle_abilities_router)
 app.include_router(sigils_router)
 app.include_router(spells_router)
 app.include_router(keys_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,7 @@
 from app.models.armor import Armor
+from app.models.battle_ability import BattleAbility
 from app.models.blade import Blade
+from app.models.break_art import BreakArt
 from app.models.consumable import Consumable
 from app.models.crafting_recipe import CraftingRecipe, MaterialRecipe
 from app.models.gem import Gem
@@ -14,7 +16,9 @@ from app.models.workshop import Workshop
 
 __all__ = [
     "Armor",
+    "BattleAbility",
     "Blade",
+    "BreakArt",
     "Consumable",
     "CraftingRecipe",
     "Gem",

--- a/app/models/battle_ability.py
+++ b/app/models/battle_ability.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class BattleAbility(Base):
+    __tablename__ = "battle_abilities"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    ability_type: Mapped[str] = mapped_column(String(20))
+    risk_cost: Mapped[int] = mapped_column(Integer)
+    effect: Mapped[str] = mapped_column(String(200))
+    power: Mapped[str] = mapped_column(String(100))

--- a/app/models/break_art.py
+++ b/app/models/break_art.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class BreakArt(Base):
+    __tablename__ = "break_arts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    weapon_type: Mapped[str] = mapped_column(String(50))
+    hp_cost: Mapped[int] = mapped_column(Integer)
+    attack_multiplier: Mapped[str] = mapped_column(String(20))
+    damage_type: Mapped[str] = mapped_column(String(20))
+    affinity: Mapped[str] = mapped_column(String(50))
+    special_effect: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    kills_required: Mapped[int] = mapped_column(Integer)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,5 +1,7 @@
 from app.routers.armor import router as armor_router
+from app.routers.battle_abilities import router as battle_abilities_router
 from app.routers.blades import router as blades_router
+from app.routers.break_arts import router as break_arts_router
 from app.routers.consumables import router as consumables_router
 from app.routers.crafting import router as crafting_router
 from app.routers.gems import router as gems_router
@@ -14,7 +16,9 @@ from app.routers.workshops import router as workshops_router
 
 __all__ = [
     "armor_router",
+    "battle_abilities_router",
     "blades_router",
+    "break_arts_router",
     "consumables_router",
     "crafting_router",
     "gems_router",

--- a/app/routers/battle_abilities.py
+++ b/app/routers/battle_abilities.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.battle_ability import BattleAbility
+from app.schemas.game_data import BattleAbilityRead
+
+router = APIRouter(prefix="/battle-abilities", tags=["battle-abilities"])
+
+
+@router.get("", response_model=list[BattleAbilityRead])
+async def list_battle_abilities(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=200),
+    q: str | None = None,
+    ability_type: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(BattleAbility)
+    if q:
+        stmt = stmt.where(BattleAbility.name.ilike(f"%{q}%"))
+    if ability_type:
+        stmt = stmt.where(BattleAbility.ability_type == ability_type)
+    stmt = stmt.order_by(BattleAbility.id).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{ability_id}", response_model=BattleAbilityRead)
+async def get_battle_ability(ability_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(BattleAbility).where(BattleAbility.id == ability_id))
+    ability = result.scalar_one_or_none()
+    if not ability:
+        raise HTTPException(status_code=404, detail="Battle Ability not found")
+    return ability

--- a/app/routers/break_arts.py
+++ b/app/routers/break_arts.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.break_art import BreakArt
+from app.schemas.game_data import BreakArtRead
+
+router = APIRouter(prefix="/break-arts", tags=["break-arts"])
+
+
+@router.get("", response_model=list[BreakArtRead])
+async def list_break_arts(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=200),
+    q: str | None = None,
+    weapon_type: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(BreakArt)
+    if q:
+        stmt = stmt.where(BreakArt.name.ilike(f"%{q}%"))
+    if weapon_type:
+        stmt = stmt.where(BreakArt.weapon_type == weapon_type)
+    stmt = stmt.order_by(BreakArt.id).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{break_art_id}", response_model=BreakArtRead)
+async def get_break_art(break_art_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(BreakArt).where(BreakArt.id == break_art_id))
+    break_art = result.scalar_one_or_none()
+    if not break_art:
+        raise HTTPException(status_code=404, detail="Break Art not found")
+    return break_art

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -216,6 +216,31 @@ class GrimoireAggregated(BaseModel):
     repeatable: bool = False
 
 
+class BreakArtRead(BaseModel):
+    id: int
+    name: str
+    weapon_type: str
+    hp_cost: int
+    attack_multiplier: str
+    damage_type: str
+    affinity: str
+    special_effect: str | None = None
+    kills_required: int
+
+    model_config = {"from_attributes": True}
+
+
+class BattleAbilityRead(BaseModel):
+    id: int
+    name: str
+    ability_type: str
+    risk_cost: int
+    effect: str
+    power: str
+
+    model_config = {"from_attributes": True}
+
+
 class WorkshopRead(BaseModel):
     id: int
     name: str


### PR DESCRIPTION
## Summary
- Add Break Arts table with 40 entries across 10 weapon types (Dagger, Sword, Great Sword, Axe/Mace, Great Axe, Staff, Heavy Mace, Polearm, Crossbow, Bare Hands)
- Add Battle Abilities table with 28 entries (14 Chain + 14 Defense abilities)
- New endpoints: `GET /break-arts`, `GET /break-arts/{id}`, `GET /battle-abilities`, `GET /battle-abilities/{id}`
- Both endpoints support `q` search and type-specific filters (`weapon_type` for break arts, `ability_type` for battle abilities)
- Chained Alembic migrations with data seeding

## Test plan
- [x] All existing tests pass
- [ ] Verify break arts endpoint returns 40 entries
- [ ] Verify battle abilities endpoint returns 28 entries
- [ ] Verify weapon_type and ability_type filters work
- [ ] Verify search parameter works