### PR TITLE
Add characters, titles, and rankings endpoints

### DIFF
--- a/alembic/versions/c4d5e6f7a8b9_add_characters_table.py
+++ b/alembic/versions/c4d5e6f7a8b9_add_characters_table.py
@@ -1,0 +1,159 @@
+"""add characters table
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3c4d5e6f7a8
+Create Date: 2026-03-21 02:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c4d5e6f7a8b9"
+down_revision: str | Sequence[str] | None = "b3c4d5e6f7a8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (name, role, description)
+CHARACTERS = [
+    # Main Characters
+    (
+        "Ashley Riot",
+        "Protagonist, VKP Riskbreaker",
+        "A member of the Valendia Knights of the Peace on a mission to pursue Sydney Losstarot.",
+    ),
+    (
+        "Sydney Losstarot",
+        "Antagonist, Mullenkamp Leader",
+        "Inheritor of the bloodline of the Priestess Mullenkamp, leader of the revival of her religion.",
+    ),
+    (
+        "Callo Merlose",
+        "VKP Inquisitor",
+        "Ashley''s partner in the Lea Monde incident, a VKP Inquisitor agent. Becomes Sydney''s hostage.",
+    ),
+    (
+        "Romeo Guildenstern",
+        "Crimson Blades Commander",
+        "Commander of the Crimson Blades, the knightly order of the Iocus priesthood.",
+    ),
+    (
+        "John Hardin",
+        "Mullenkamp Second-in-Command",
+        "Sydney''s faithful servant, aids in leading Mullenkamp and setting up Sigils.",
+    ),
+    (
+        "Jan Rosencrantz",
+        "Mercenary",
+        "Red-clad swashbuckler, an immoral mercenary immune to the Dark with no allegiance.",
+    ),
+    (
+        "Lady Samantha",
+        "Crimson Blades Knight",
+        "Romeo''s faithful companion, the only one who shows worry for the loss of troops.",
+    ),
+    (
+        "Duke Bardorba",
+        "Political Figure",
+        "Hero of the Valendian Civil War and influential political figure controlling many events.",
+    ),
+    # Supporting Characters
+    (
+        "Father Duane",
+        "Crimson Blades Captain",
+        "One of the first Blades to fall. His death drives his brother Grissom to revenge.",
+    ),
+    (
+        "Father Grissom",
+        "Crimson Blades Commander",
+        "Brother of Duane, a polished cleric hiding ruthlessness behind elegant niceties.",
+    ),
+    (
+        "Sir Tieger",
+        "Crimson Blades Knight",
+        "Shown only with Lady Neesa. Gives up his life so she may tell the tale.",
+    ),
+    (
+        "Lady Neesa",
+        "Crimson Blades Knight",
+        "Close associate of Sir Tieger, a hardened warrior.",
+    ),
+    (
+        "Inquisitor Heldricht",
+        "VKP Head Inquisitor",
+        "Supervises VKP Inquisitors. Terse and direct with her pageboy cut and thin cigars.",
+    ),
+    (
+        "Steward LeSait",
+        "VKP Commander",
+        "Commander of the Valendia Knights of the Peace.",
+    ),
+    (
+        "Cardinal Batistum",
+        "Religious Leader",
+        "Powerful figure in Valendia''s religion, commands the Crimson Blades.",
+    ),
+    # Minor Characters
+    (
+        "Mandel",
+        "Crimson Blades",
+        "Killed by Ashley, reanimated as undead by the Dark.",
+    ),
+    (
+        "Goodwin",
+        "Crimson Blades",
+        "Trapped in the Wine Cellar, teaches Ashley about Cloudstones.",
+    ),
+    (
+        "Sackheim",
+        "Crimson Blades",
+        "Trapped in the Wine Cellar with Goodwin.",
+    ),
+    (
+        "Bejart",
+        "Crimson Blades",
+        "Footsoldier slain by Ashley in the Town Center.",
+    ),
+    (
+        "Sarjik",
+        "Crimson Blades",
+        "Footsoldier slain by Ashley in the Town Center.",
+    ),
+    (
+        "Faendos",
+        "Crimson Blades",
+        "Accompanies Grissom into Snowfly Forest, disappears.",
+    ),
+    (
+        "Lamkin",
+        "Crimson Blades",
+        "Accompanies Grissom into Snowfly Forest, disappears.",
+    ),
+]
+
+
+def upgrade() -> None:
+    """Create characters table and populate with data."""
+    op.create_table(
+        "characters",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("role", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.Text(), server_default="", nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    for name, role, description in CHARACTERS:
+        op.execute(
+            f"INSERT INTO characters (name, role, description) "
+            f"VALUES ('{name}', '{role}', '{description}')"
+        )
+
+
+def downgrade() -> None:
+    """Drop characters table."""
+    op.drop_table("characters")

--- a/alembic/versions/d5e6f7a8b9c0_add_titles_table.py
+++ b/alembic/versions/d5e6f7a8b9c0_add_titles_table.py
@@ -1,0 +1,122 @@
+"""add titles table
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-03-21 02:01:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d5e6f7a8b9c0"
+down_revision: str | Sequence[str] | None = "c4d5e6f7a8b9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (number, name, requirement)
+TITLES = [
+    (1, "Seeker of Truth", "Finish the game once"),
+    (2, "Conqueror of the Dark", "Finish the game within ten hours"),
+    (3, "Treasure Hunter", "Check all the chests in the game"),
+    (4, "Wanderer in Darkness", "Visit every map location in the game"),
+    (5, "Destroyer of Gaeus", "Defeat Damascus Golem in Forgotten Passage"),
+    (6, "Hunter of the Snowplains", "Defeat Damascus Crab in Snowfly Forest East"),
+    (7, "Ally of the Wood", "Defeat Ravana in Iron Maiden B2"),
+    (8, "Slayer of the Wyrm", "Defeat Dragon Zombie in Iron Maiden B2"),
+    (9, "Vanquisher of Death", "Defeat Death and Ogre Zombie in Iron Maiden B2"),
+    (10, "Warrior of Asura", "Defeat Asura in Iron Maiden B3"),
+    (
+        11,
+        "Conqueror of Time",
+        "Receive an ''Excellent!!'' rating for all Time Attack battles",
+    ),
+    (12, "Knight of Brilliance", "Turn out more than 30 Chain Abilities in a row"),
+    (13, "Bearer of the New World", "Find the rare item Gold Key"),
+    (14, "Hoard-Finder", "Find the rare item Chest Key"),
+    (15, "Hands of Might", "Master all Break Arts"),
+    (16, "Hands of Skill", "Master all Battle Abilities"),
+    (17, "Wanderer of the Wyrding", "Finish the game without saving at any point"),
+    (18, "Adventurer of Legend", "Finish the game without using Magic"),
+    (19, "Lone Werreour", "Finish the game without using Battle Abilities"),
+    (20, "Knight of Pride", "Finish the game without using Break Arts"),
+    (21, "Blood-thirsty Hunter", "Defeat each class of monster 5,000 times"),
+    (
+        22,
+        "Master of Arms",
+        "Attack enemies 5,000 times with each type of weapon",
+    ),
+    (
+        23,
+        "Silent Assassin",
+        "Attack over 500 times with a weapon in the Dagger group",
+    ),
+    (
+        24,
+        "Great Swordsman",
+        "Attack over 500 times with a weapon in the Sword group",
+    ),
+    (
+        25,
+        "Master of Blades",
+        "Attack over 500 times with a weapon in the Great Sword group",
+    ),
+    (
+        26,
+        "Steel Dragoon",
+        "Attack over 500 times with a weapon in the Axe/Mace group",
+    ),
+    (
+        27,
+        "The Earthshaker",
+        "Attack over 500 times with a weapon in the Great Axe group",
+    ),
+    (
+        28,
+        "Sweeper of the Dark",
+        "Attack over 500 times with a weapon in the Staff group",
+    ),
+    (
+        29,
+        "Acolyte of Iron",
+        "Attack over 500 times with a weapon in the Heavy Mace group",
+    ),
+    (
+        30,
+        "Spearsman of the Gale",
+        "Attack over 500 times with a weapon in the Polearm group",
+    ),
+    (
+        31,
+        "Heaven''s Huntsman",
+        "Attack over 500 times with a weapon in the Crossbow group",
+    ),
+    (32, "Master of Martial Artist", "Attack over 500 times with bare hands"),
+]
+
+
+def upgrade() -> None:
+    """Create titles table and populate with data."""
+    op.create_table(
+        "titles",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("number", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("requirement", sa.Text(), server_default="", nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    for number, name, requirement in TITLES:
+        op.execute(
+            f"INSERT INTO titles (number, name, requirement) "
+            f"VALUES ({number}, '{name}', '{requirement}')"
+        )
+
+
+def downgrade() -> None:
+    """Drop titles table."""
+    op.drop_table("titles")

--- a/alembic/versions/e6f7a8b9c0d1_add_rankings_table.py
+++ b/alembic/versions/e6f7a8b9c0d1_add_rankings_table.py
@@ -1,0 +1,62 @@
+"""add rankings table
+
+Revision ID: e6f7a8b9c0d1
+Revises: d5e6f7a8b9c0
+Create Date: 2026-03-21 02:02:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e6f7a8b9c0d1"
+down_revision: str | Sequence[str] | None = "d5e6f7a8b9c0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (level, name, requirement)
+RANKINGS = [
+    (1, "Normal Agent", "0 Points"),
+    (2, "Gladiator", "500,000 Points"),
+    (3, "Daredevil", "1,000,000 Points"),
+    (4, "Berserker", "2,000,000 Points"),
+    (5, "Destroyer", "3,000,000 Points"),
+    (6, "Spectrebane", "4,000,000 Points"),
+    (7, "Paladin", "5,000,000 Points"),
+    (8, "Mystic Wanderer", "8,000,000 Points"),
+    (9, "Blade Master", "12,000,000 Points"),
+    (10, "Master Gladiator", "16,000,000 Points"),
+    (11, "Courageous Adventurer", "24,000,000 Points"),
+    (12, "Dragon Slayer", "32,000,000 Points"),
+    (13, "Raging Berserker", "40,000,000 Points"),
+    (14, "Radiant Knight", "60,000,000 Points + 8 Titles"),
+    (15, "Grand Paladin", "75,000,000 Points + 12 Titles"),
+    (16, "Grand Master Breaker", "100,000,000 Points + 16 Titles"),
+]
+
+
+def upgrade() -> None:
+    """Create rankings table and populate with data."""
+    op.create_table(
+        "rankings",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("level", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("requirement", sa.String(length=200), server_default="", nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    for level, name, requirement in RANKINGS:
+        op.execute(
+            f"INSERT INTO rankings (level, name, requirement) "
+            f"VALUES ({level}, '{name}', '{requirement}')"
+        )
+
+
+def downgrade() -> None:
+    """Drop rankings table."""
+    op.drop_table("rankings")

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from app.routers import (
     battle_abilities_router,
     blades_router,
     break_arts_router,
+    characters_router,
     consumables_router,
     crafting_router,
     gems_router,
@@ -23,8 +24,10 @@ from app.routers import (
     grips_router,
     keys_router,
     materials_router,
+    rankings_router,
     sigils_router,
     spells_router,
+    titles_router,
     user_router,
     workshops_router,
 )
@@ -103,6 +106,9 @@ app.include_router(keys_router)
 app.include_router(grimoires_router)
 app.include_router(workshops_router)
 app.include_router(crafting_router)
+app.include_router(characters_router)
+app.include_router(titles_router)
+app.include_router(rankings_router)
 app.include_router(user_router)
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,7 @@ from app.models.armor import Armor
 from app.models.battle_ability import BattleAbility
 from app.models.blade import Blade
 from app.models.break_art import BreakArt
+from app.models.character import Character
 from app.models.consumable import Consumable
 from app.models.crafting_recipe import CraftingRecipe, MaterialRecipe
 from app.models.gem import Gem
@@ -10,8 +11,10 @@ from app.models.grip import Grip
 from app.models.inventory import Inventory, InventoryItem
 from app.models.key import Key
 from app.models.material import Material
+from app.models.ranking import Ranking
 from app.models.sigil import Sigil
 from app.models.spell import Spell
+from app.models.title import Title
 from app.models.workshop import Workshop
 
 __all__ = [
@@ -19,6 +22,7 @@ __all__ = [
     "BattleAbility",
     "Blade",
     "BreakArt",
+    "Character",
     "Consumable",
     "CraftingRecipe",
     "Gem",
@@ -29,7 +33,9 @@ __all__ = [
     "Key",
     "Material",
     "MaterialRecipe",
+    "Ranking",
     "Sigil",
     "Spell",
+    "Title",
     "Workshop",
 ]

--- a/app/models/character.py
+++ b/app/models/character.py
@@ -1,0 +1,13 @@
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Character(Base):
+    __tablename__ = "characters"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    role: Mapped[str] = mapped_column(String(100))
+    description: Mapped[str] = mapped_column(Text, default="")

--- a/app/models/ranking.py
+++ b/app/models/ranking.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Ranking(Base):
+    __tablename__ = "rankings"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    level: Mapped[int] = mapped_column(Integer)
+    name: Mapped[str] = mapped_column(String(100))
+    requirement: Mapped[str] = mapped_column(String(200), default="")

--- a/app/models/title.py
+++ b/app/models/title.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Title(Base):
+    __tablename__ = "titles"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    number: Mapped[int] = mapped_column(Integer)
+    name: Mapped[str] = mapped_column(String(100))
+    requirement: Mapped[str] = mapped_column(Text, default="")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -2,6 +2,7 @@ from app.routers.armor import router as armor_router
 from app.routers.battle_abilities import router as battle_abilities_router
 from app.routers.blades import router as blades_router
 from app.routers.break_arts import router as break_arts_router
+from app.routers.characters import router as characters_router
 from app.routers.consumables import router as consumables_router
 from app.routers.crafting import router as crafting_router
 from app.routers.gems import router as gems_router
@@ -9,8 +10,10 @@ from app.routers.grimoires import router as grimoires_router
 from app.routers.grips import router as grips_router
 from app.routers.keys import router as keys_router
 from app.routers.materials import router as materials_router
+from app.routers.rankings import router as rankings_router
 from app.routers.sigils import router as sigils_router
 from app.routers.spells import router as spells_router
+from app.routers.titles import router as titles_router
 from app.routers.user import router as user_router
 from app.routers.workshops import router as workshops_router
 
@@ -19,6 +22,7 @@ __all__ = [
     "battle_abilities_router",
     "blades_router",
     "break_arts_router",
+    "characters_router",
     "consumables_router",
     "crafting_router",
     "gems_router",
@@ -26,8 +30,10 @@ __all__ = [
     "grips_router",
     "keys_router",
     "materials_router",
+    "rankings_router",
     "sigils_router",
     "spells_router",
+    "titles_router",
     "user_router",
     "workshops_router",
 ]

--- a/app/routers/characters.py
+++ b/app/routers/characters.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.character import Character
+from app.schemas.game_data import CharacterRead
+
+router = APIRouter(prefix="/characters", tags=["characters"])
+
+
+@router.get("", response_model=list[CharacterRead])
+async def list_characters(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=200),
+    q: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(Character)
+    if q:
+        stmt = stmt.where(Character.name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Character.id).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{character_id}", response_model=CharacterRead)
+async def get_character(character_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(Character).where(Character.id == character_id))
+    character = result.scalar_one_or_none()
+    if not character:
+        raise HTTPException(status_code=404, detail="Character not found")
+    return character

--- a/app/routers/rankings.py
+++ b/app/routers/rankings.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.ranking import Ranking
+from app.schemas.game_data import RankingRead
+
+router = APIRouter(prefix="/rankings", tags=["rankings"])
+
+
+@router.get("", response_model=list[RankingRead])
+async def list_rankings(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=200),
+    q: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(Ranking)
+    if q:
+        stmt = stmt.where(Ranking.name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Ranking.level).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{ranking_id}", response_model=RankingRead)
+async def get_ranking(ranking_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(Ranking).where(Ranking.id == ranking_id))
+    ranking = result.scalar_one_or_none()
+    if not ranking:
+        raise HTTPException(status_code=404, detail="Ranking not found")
+    return ranking

--- a/app/routers/titles.py
+++ b/app/routers/titles.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.title import Title
+from app.schemas.game_data import TitleRead
+
+router = APIRouter(prefix="/titles", tags=["titles"])
+
+
+@router.get("", response_model=list[TitleRead])
+async def list_titles(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=200),
+    q: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(Title)
+    if q:
+        stmt = stmt.where(Title.name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Title.number).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{title_id}", response_model=TitleRead)
+async def get_title(title_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(Title).where(Title.id == title_id))
+    title = result.scalar_one_or_none()
+    if not title:
+        raise HTTPException(status_code=404, detail="Title not found")
+    return title

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -241,6 +241,33 @@ class BattleAbilityRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class CharacterRead(BaseModel):
+    id: int
+    name: str
+    role: str
+    description: str = ""
+
+    model_config = {"from_attributes": True}
+
+
+class TitleRead(BaseModel):
+    id: int
+    number: int
+    name: str
+    requirement: str = ""
+
+    model_config = {"from_attributes": True}
+
+
+class RankingRead(BaseModel):
+    id: int
+    level: int
+    name: str
+    requirement: str = ""
+
+    model_config = {"from_attributes": True}
+
+
 class WorkshopRead(BaseModel):
     id: int
     name: str


### PR DESCRIPTION
## Summary
- Add Characters endpoint (22 entries) with name, role, and description fields
- Add Titles endpoint (32 entries) with number, name, and requirement fields
- Add Rankings endpoint (16 entries) with level, name, and requirement fields

Each resource includes:
- SQLAlchemy model, Pydantic schema, FastAPI router (list + detail)
- Chained Alembic migration with seed data from scraped wiki/guide sources

## Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes (8/8)
- [x] Migrations apply cleanly (`alembic upgrade head`)
- [ ] GET /characters, /titles, /rankings return expected data
- [ ] GET /characters/{id}, /titles/{id}, /rankings/{id} return detail
- [ ] Search via `?q=` param works on characters