### PR TITLE
feat: add areas and rooms tables with endpoints

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,6 +11,7 @@ from app.database import Base
 
 # Import all models so Alembic can detect them
 from app.models import (  # noqa: F401
+    Area,
     Armor,
     Blade,
     Consumable,
@@ -21,6 +22,7 @@ from app.models import (  # noqa: F401
     Key,
     Material,
     MaterialRecipe,
+    Room,
     Sigil,
     Spell,
     Workshop,

--- a/alembic/versions/a7b8c9d0e1f2_add_areas_and_rooms_tables.py
+++ b/alembic/versions/a7b8c9d0e1f2_add_areas_and_rooms_tables.py
@@ -1,0 +1,328 @@
+"""add areas and rooms tables
+
+Revision ID: a7b8c9d0e1f2
+Revises: aa9dcf05f69f
+Create Date: 2026-03-21 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7b8c9d0e1f2"
+down_revision: str | Sequence[str] | None = "aa9dcf05f69f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# ── Area and Room data ────────────────────────────────────────────
+# Compiled from chests, grimoires, sigils, keys, and workshops.
+# "Town Centre" normalized to "Town Center".
+
+AREAS = [
+    "Abandoned Mines B1",
+    "Abandoned Mines B2",
+    "Catacombs",
+    "Escapeway",
+    "Forgotten Pathway",
+    "Great Cathedral B1",
+    "Great Cathedral L1",
+    "Great Cathedral L2",
+    "Great Cathedral L3",
+    "Iron Maiden B1",
+    "Iron Maiden B2",
+    "Iron Maiden B3",
+    "Limestone Quarry",
+    "Sanctum",
+    "Snowfly Forest",
+    "Snowfly Forest East",
+    "Temple of Kiltia",
+    "The Keep",
+    "Town Center East",
+    "Town Center South",
+    "Town Center West",
+    "Undercity East",
+    "Undercity West",
+    "Wine Cellar",
+]
+
+# (area_name, room_name) — every unique room from all data sources
+ROOMS = [
+    ("Abandoned Mines B1", "Battle's Beginning"),
+    ("Abandoned Mines B1", "Coal Mine Storage"),
+    ("Abandoned Mines B1", "Miners' Resting Hall"),
+    ("Abandoned Mines B1", "Mining Regrets"),
+    ("Abandoned Mines B1", "Rust in Peace"),
+    ("Abandoned Mines B1", "The Battle's Beginning"),
+    ("Abandoned Mines B1", "The Smeltry"),
+    ("Abandoned Mines B1", "Traitor's Parting"),
+    ("Abandoned Mines B2", "Acolyte's Burial Vault"),
+    ("Abandoned Mines B2", "Delusions of Happiness"),
+    ("Abandoned Mines B2", "Dining in Darkness"),
+    ("Abandoned Mines B2", "Hidden Resources"),
+    ("Abandoned Mines B2", "Suicidal Desires"),
+    ("Abandoned Mines B2", "The Miner's End"),
+    ("Abandoned Mines B2", "Tomb of the Reborn"),
+    ("Catacombs", "Bandits' Hideout"),
+    ("Catacombs", "Beast's Domain"),
+    ("Catacombs", "Rodent-Ridden Chamber"),
+    ("Catacombs", "The Beast's Domain"),
+    ("Catacombs", "The Lamenting Mother"),
+    ("Catacombs", "The Withered Spring"),
+    ("Catacombs", "Withered Spring"),
+    ("Escapeway", "Buried Alive"),
+    ("Escapeway", "Fear and Loathing"),
+    ("Escapeway", "Where Body and Soul Part"),
+    ("Forgotten Pathway", "Awaiting Retribution"),
+    ("Forgotten Pathway", "The Fallen Knight"),
+    ("Great Cathedral B1", "Order and Chaos"),
+    ("Great Cathedral B1", "Truth and Lies"),
+    ("Great Cathedral L1", "A Light in the Dark"),
+    ("Great Cathedral L1", "Monk's Leap"),
+    ("Great Cathedral L1", "The Flayed Confessional"),
+    ("Great Cathedral L1", "Where Darkness Spreads"),
+    ("Great Cathedral L2", "An Arrow into Darkness"),
+    ("Great Cathedral L2", "Hall of Broken Vows"),
+    ("Great Cathedral L2", "Maelstrom of Malice"),
+    ("Great Cathedral L2", "What Ails You, Kills You"),
+    ("Great Cathedral L3", "Hopes of the Idealist"),
+    ("Iron Maiden B1", "Burial"),
+    ("Iron Maiden B1", "Knotting"),
+    ("Iron Maiden B1", "Spanish Tickler"),
+    ("Iron Maiden B1", "Starvation"),
+    ("Iron Maiden B1", "The Branks"),
+    ("Iron Maiden B1", "The Cauldron"),
+    ("Iron Maiden B1", "The Ducking Stool"),
+    ("Iron Maiden B1", "The Judas Cradle"),
+    ("Iron Maiden B1", "The Wheel"),
+    ("Iron Maiden B2", "Lead Sprinkler"),
+    ("Iron Maiden B2", "Ordeal by Fire"),
+    ("Iron Maiden B2", "Pressing"),
+    ("Iron Maiden B2", "Squassation"),
+    ("Iron Maiden B2", "The Saw"),
+    ("Iron Maiden B2", "The Shin-Vice"),
+    ("Iron Maiden B3", "Dunking the Witch"),
+    ("Iron Maiden B3", "Saint Elmo's Belt"),
+    ("Iron Maiden B3", "The Iron Maiden"),
+    ("Limestone Quarry", "Bonds of Friendship"),
+    ("Limestone Quarry", "Companions in Arms"),
+    ("Limestone Quarry", "Dream of the Holy Land"),
+    ("Limestone Quarry", "Drowned in Fleeting Joy"),
+    ("Limestone Quarry", "Excavated Hollow"),
+    ("Limestone Quarry", "Hall of the Wage-Paying"),
+    ("Limestone Quarry", "Stone and Sulfurous Fire"),
+    ("Sanctum", "Alchemists' Laboratory"),
+    ("Sanctum", "Hall of Sacrilege"),
+    ("Sanctum", "The Cleansing Chantry"),
+    ("Sanctum", "Theology Classroom"),
+    ("Snowfly Forest", "Forest River"),
+    ("Snowfly Forest", "Hewn from Nature"),
+    ("Snowfly Forest", "Nature's Womb"),
+    ("Snowfly Forest", "Return to the Land"),
+    ("Snowfly Forest East", "Nature's Womb"),
+    ("Temple of Kiltia", "Chapel of Meschaunce"),
+    ("Temple of Kiltia", "Hall of Prayer"),
+    ("Temple of Kiltia", "The Chapel of Meschaunce"),
+    ("Temple of Kiltia", "Those who Fear the Light"),
+    ("The Keep", "The Warrior's Rest"),
+    ("Town Center East", "Gharmes Walk"),
+    ("Town Center East", "Rue Crimnade"),
+    ("Town Center East", "Rue Fisserano"),
+    ("Town Center East", "The House Gilgitte"),
+    ("Town Center South", "The House Khazabas"),
+    ("Town Center West", "Rene Coast Road"),
+    ("Town Center West", "Tircolas Flow"),
+    ("Undercity East", "Arms Against Invaders"),
+    ("Undercity East", "Bazaar of the Bizarre"),
+    ("Undercity East", "Catspaw Blackmarket"),
+    ("Undercity East", "Gemsword Blackmarket"),
+    ("Undercity East", "Place of Free Words"),
+    ("Undercity East", "Sale of the Sword"),
+    ("Undercity East", "Weapons Not Allowed"),
+    ("Undercity East", "Where Black Waters Ran"),
+    ("Undercity West", "Bite The Master's Wounds"),
+    ("Undercity West", "Corner of Prayers"),
+    ("Undercity West", "Crumbling Market"),
+    ("Undercity West", "Fear of the Fall"),
+    ("Undercity West", "Larder for a Lean Winter"),
+    ("Undercity West", "Nameless Dark Oblivion"),
+    ("Undercity West", "Remembering Days of Yore"),
+    ("Undercity West", "Sewer of Ravenous Rats"),
+    ("Undercity West", "Sinner's Corner"),
+    ("Undercity West", "The Children's Hideout"),
+    ("Undercity West", "The Crumbling Market"),
+    ("Undercity West", "The Washing-Woman's Way"),
+    ("Undercity West", "Underdark Fishmarket"),
+    ("Wine Cellar", "Blackmarket of Wines"),
+    ("Wine Cellar", "Gallows"),
+    ("Wine Cellar", "The Gallows"),
+    ("Wine Cellar", "The Hero's Winehall"),
+    ("Wine Cellar", "The Reckoning Room"),
+    ("Wine Cellar", "Worker's Breakroom"),
+]
+
+# Normalization map: old area string -> normalized area name
+# Used when matching existing table rows to area records
+AREA_NORMALIZE = {
+    "Town Centre South": "Town Center South",
+    "Town Centre East": "Town Center East",
+    "Town Centre West": "Town Center West",
+}
+
+
+def _esc(s):
+    """Escape single quotes for SQL."""
+    return s.replace("'", "''")
+
+
+def upgrade() -> None:
+    """Create areas and rooms tables, populate, add room_id to existing tables."""
+    conn = op.get_bind()
+
+    # ── Step 1: Create areas table ────────────────────────────────
+    op.create_table(
+        "areas",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False, unique=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # ── Step 2: Create rooms table ────────────────────────────────
+    op.create_table(
+        "rooms",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "area_id",
+            sa.Integer(),
+            sa.ForeignKey("areas.id"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # ── Step 3: Insert areas ──────────────────────────────────────
+    for area_name in AREAS:
+        conn.execute(sa.text(f"INSERT INTO areas (name) VALUES ('{_esc(area_name)}')"))
+
+    # ── Step 4: Insert rooms ──────────────────────────────────────
+    for area_name, room_name in ROOMS:
+        conn.execute(
+            sa.text(
+                f"INSERT INTO rooms (area_id, name) "
+                f"SELECT id, '{_esc(room_name)}' FROM areas "
+                f"WHERE name = '{_esc(area_name)}'"
+            )
+        )
+
+    # ── Step 5: Add room_id columns to existing tables ────────────
+    op.add_column(
+        "chests",
+        sa.Column("room_id", sa.Integer(), sa.ForeignKey("rooms.id"), nullable=True),
+    )
+    op.add_column(
+        "grimoires",
+        sa.Column("room_id", sa.Integer(), sa.ForeignKey("rooms.id"), nullable=True),
+    )
+    op.add_column(
+        "sigils",
+        sa.Column("room_id", sa.Integer(), sa.ForeignKey("rooms.id"), nullable=True),
+    )
+    op.add_column(
+        "keys",
+        sa.Column("room_id", sa.Integer(), sa.ForeignKey("rooms.id"), nullable=True),
+    )
+    op.add_column(
+        "workshops",
+        sa.Column("room_id", sa.Integer(), sa.ForeignKey("rooms.id"), nullable=True),
+    )
+
+    # ── Step 6: Populate room_id for chests ───────────────────────
+    # Chests use "Town Centre" in DB, normalize to "Town Center"
+    conn.execute(
+        sa.text(
+            """
+            UPDATE chests SET room_id = r.id
+            FROM rooms r
+            JOIN areas a ON r.area_id = a.id
+            WHERE a.name = REPLACE(REPLACE(chests.area,
+                'Town Centre South', 'Town Center South'),
+                'Town Centre East', 'Town Center East')
+            AND r.name = chests.room
+            """
+        )
+    )
+
+    # ── Step 7: Populate room_id for grimoires ────────────────────
+    # Grimoire area strings use "Town Center" (already normalized) and
+    # room strings with escaped apostrophes like "The Beast''s Domain"
+    # in the migration data, but actual DB stores them unescaped.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE grimoires SET room_id = r.id
+            FROM rooms r
+            JOIN areas a ON r.area_id = a.id
+            WHERE a.name = grimoires.area
+            AND r.name = grimoires.room
+            """
+        )
+    )
+
+    # ── Step 8: Populate room_id for sigils ───────────────────────
+    conn.execute(
+        sa.text(
+            """
+            UPDATE sigils SET room_id = r.id
+            FROM rooms r
+            JOIN areas a ON r.area_id = a.id
+            WHERE a.name = sigils.area
+            AND r.name = sigils.room
+            """
+        )
+    )
+
+    # ── Step 9: Populate room_id for keys ─────────────────────────
+    # Keys have area/room strings; some keys have non-room areas like
+    # "Beat the game" — those will remain NULL.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE keys SET room_id = r.id
+            FROM rooms r
+            JOIN areas a ON r.area_id = a.id
+            WHERE a.name = keys.area
+            AND r.name = keys.room
+            """
+        )
+    )
+
+    # ── Step 10: Populate room_id for workshops ───────────────────
+    # Workshop area format is "Area: Room" — need to split and match.
+    # We update each workshop by matching the split values.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE workshops SET room_id = r.id
+            FROM rooms r
+            JOIN areas a ON r.area_id = a.id
+            WHERE workshops.area LIKE '%: %'
+            AND a.name = TRIM(SPLIT_PART(workshops.area, ': ', 1))
+            AND r.name = TRIM(SPLIT_PART(workshops.area, ': ', 2))
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Remove room_id columns and drop areas/rooms tables."""
+    op.drop_column("workshops", "room_id")
+    op.drop_column("keys", "room_id")
+    op.drop_column("sigils", "room_id")
+    op.drop_column("grimoires", "room_id")
+    op.drop_column("chests", "room_id")
+    op.drop_table("rooms")
+    op.drop_table("areas")

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from slowapi.util import get_remote_address
 from app.config import settings
 from app.logging import setup_logging
 from app.routers import (
+    areas_router,
     armor_router,
     battle_abilities_router,
     blades_router,
@@ -26,6 +27,7 @@ from app.routers import (
     keys_router,
     materials_router,
     rankings_router,
+    rooms_router,
     sigils_router,
     spells_router,
     titles_router,
@@ -111,6 +113,8 @@ app.include_router(crafting_router)
 app.include_router(characters_router)
 app.include_router(titles_router)
 app.include_router(rankings_router)
+app.include_router(areas_router)
+app.include_router(rooms_router)
 app.include_router(user_router)
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.area import Area
 from app.models.armor import Armor
 from app.models.battle_ability import BattleAbility
 from app.models.blade import Blade
@@ -13,12 +14,14 @@ from app.models.inventory import Inventory, InventoryItem
 from app.models.key import Key
 from app.models.material import Material
 from app.models.ranking import Ranking
+from app.models.room import Room
 from app.models.sigil import Sigil
 from app.models.spell import Spell
 from app.models.title import Title
 from app.models.workshop import Workshop
 
 __all__ = [
+    "Area",
     "Armor",
     "BattleAbility",
     "Blade",
@@ -37,6 +40,7 @@ __all__ = [
     "Material",
     "MaterialRecipe",
     "Ranking",
+    "Room",
     "Sigil",
     "Spell",
     "Title",

--- a/app/models/area.py
+++ b/app/models/area.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.room import Room
+
+
+class Area(Base):
+    __tablename__ = "areas"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), unique=True)
+
+    rooms: Mapped[list[Room]] = relationship("Room", back_populates="area", lazy="selectin")

--- a/app/models/chest.py
+++ b/app/models/chest.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.room import Room
 
 
 class Chest(Base):
@@ -10,11 +17,13 @@ class Chest(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     area: Mapped[str] = mapped_column(String(100))
     room: Mapped[str] = mapped_column(String(200))
+    room_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("rooms.id"), nullable=True)
     lock_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
-    items: Mapped[list["ChestItem"]] = relationship(
+    items: Mapped[list[ChestItem]] = relationship(
         back_populates="chest", cascade="all, delete-orphan", lazy="selectin"
     )
+    room_rel: Mapped[Room | None] = relationship("Room", lazy="selectin")
 
 
 class ChestItem(Base):
@@ -28,4 +37,4 @@ class ChestItem(Base):
     gem_slots: Mapped[int | None] = mapped_column(Integer, nullable=True)
     quantity: Mapped[int] = mapped_column(Integer, server_default="1")
 
-    chest: Mapped["Chest"] = relationship(back_populates="items")
+    chest: Mapped[Chest] = relationship(back_populates="items")

--- a/app/models/grimoire.py
+++ b/app/models/grimoire.py
@@ -1,7 +1,14 @@
-from sqlalchemy import Boolean, Integer, String
-from sqlalchemy.orm import Mapped, mapped_column
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.room import Room
 
 
 class Grimoire(Base):
@@ -12,6 +19,9 @@ class Grimoire(Base):
     spell_name: Mapped[str] = mapped_column(String(100), default="")
     area: Mapped[str] = mapped_column(String(100), default="")
     room: Mapped[str] = mapped_column(String(200), default="")
+    room_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("rooms.id"), nullable=True)
     source: Mapped[str] = mapped_column(String(200), default="")
     drop_rate: Mapped[str] = mapped_column(String(50), default="")
     repeatable: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    room_rel: Mapped[Room | None] = relationship("Room", lazy="selectin")

--- a/app/models/key.py
+++ b/app/models/key.py
@@ -1,7 +1,14 @@
-from sqlalchemy import Integer, String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.room import Room
 
 
 class Key(Base):
@@ -11,5 +18,8 @@ class Key(Base):
     name: Mapped[str] = mapped_column(String(100))
     area: Mapped[str] = mapped_column(String(100), default="")
     room: Mapped[str] = mapped_column(String(100), default="")
+    room_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("rooms.id"), nullable=True)
     source: Mapped[str] = mapped_column(String(200), default="")
     locations_used: Mapped[str] = mapped_column(Text, default="")
+
+    room_rel: Mapped[Room | None] = relationship("Room", lazy="selectin")

--- a/app/models/room.py
+++ b/app/models/room.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.area import Area
+
+
+class Room(Base):
+    __tablename__ = "rooms"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    area_id: Mapped[int] = mapped_column(Integer, ForeignKey("areas.id"))
+    name: Mapped[str] = mapped_column(String(200))
+
+    area: Mapped[Area] = relationship("Area", back_populates="rooms")

--- a/app/models/sigil.py
+++ b/app/models/sigil.py
@@ -1,7 +1,14 @@
-from sqlalchemy import Integer, String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.room import Room
 
 
 class Sigil(Base):
@@ -11,5 +18,8 @@ class Sigil(Base):
     name: Mapped[str] = mapped_column(String(100))
     area: Mapped[str] = mapped_column(String(100), default="")
     room: Mapped[str] = mapped_column(String(100), default="")
+    room_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("rooms.id"), nullable=True)
     source: Mapped[str] = mapped_column(String(200), default="")
     door_unlocks: Mapped[str] = mapped_column(Text, default="")
+
+    room_rel: Mapped[Room | None] = relationship("Room", lazy="selectin")

--- a/app/models/workshop.py
+++ b/app/models/workshop.py
@@ -1,7 +1,14 @@
-from sqlalchemy import Integer, String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.room import Room
 
 
 class Workshop(Base):
@@ -10,5 +17,8 @@ class Workshop(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(100))
     area: Mapped[str] = mapped_column(String(200), default="")
+    room_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("rooms.id"), nullable=True)
     available_materials: Mapped[str] = mapped_column(String(300), default="")
     description: Mapped[str] = mapped_column(Text, default="")
+
+    room_rel: Mapped[Room | None] = relationship("Room", lazy="selectin")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,3 +1,4 @@
+from app.routers.areas import router as areas_router
 from app.routers.armor import router as armor_router
 from app.routers.battle_abilities import router as battle_abilities_router
 from app.routers.blades import router as blades_router
@@ -12,6 +13,7 @@ from app.routers.grips import router as grips_router
 from app.routers.keys import router as keys_router
 from app.routers.materials import router as materials_router
 from app.routers.rankings import router as rankings_router
+from app.routers.rooms import router as rooms_router
 from app.routers.sigils import router as sigils_router
 from app.routers.spells import router as spells_router
 from app.routers.titles import router as titles_router
@@ -19,6 +21,7 @@ from app.routers.user import router as user_router
 from app.routers.workshops import router as workshops_router
 
 __all__ = [
+    "areas_router",
     "armor_router",
     "battle_abilities_router",
     "blades_router",
@@ -33,6 +36,7 @@ __all__ = [
     "keys_router",
     "materials_router",
     "rankings_router",
+    "rooms_router",
     "sigils_router",
     "spells_router",
     "titles_router",

--- a/app/routers/areas.py
+++ b/app/routers/areas.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.area import Area
+from app.schemas.game_data import AreaDetailRead, AreaRead
+
+router = APIRouter(prefix="/areas", tags=["areas"])
+
+
+@router.get("", response_model=list[AreaRead])
+async def list_areas(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    q: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(Area)
+    if q:
+        stmt = stmt.where(Area.name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Area.id).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{area_id}", response_model=AreaDetailRead)
+async def get_area(area_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(select(Area).where(Area.id == area_id))
+    area = result.scalar_one_or_none()
+    if not area:
+        raise HTTPException(status_code=404, detail="Area not found")
+    # Serialize rooms with area_name
+    rooms = [
+        {"id": r.id, "name": r.name, "area_id": r.area_id, "area_name": area.name}
+        for r in area.rooms
+    ]
+    return {"id": area.id, "name": area.name, "rooms": rooms}

--- a/app/routers/rooms.py
+++ b/app/routers/rooms.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.database import get_async_session
+from app.models.room import Room
+from app.schemas.game_data import RoomDetailRead, RoomRead
+
+router = APIRouter(prefix="/rooms", tags=["rooms"])
+
+
+@router.get("", response_model=list[RoomRead])
+async def list_rooms(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(200, ge=1, le=500),
+    area: int | None = None,
+    q: str | None = None,
+    session: AsyncSession = Depends(get_async_session),
+):
+    stmt = select(Room).options(selectinload(Room.area))
+    if area:
+        stmt = stmt.where(Room.area_id == area)
+    if q:
+        stmt = stmt.where(Room.name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Room.id).offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    rooms = result.scalars().all()
+    return [
+        {
+            "id": r.id,
+            "name": r.name,
+            "area_id": r.area_id,
+            "area_name": r.area.name if r.area else "",
+        }
+        for r in rooms
+    ]
+
+
+@router.get("/{room_id}", response_model=RoomDetailRead)
+async def get_room(room_id: int, session: AsyncSession = Depends(get_async_session)):
+    result = await session.execute(
+        select(Room).options(selectinload(Room.area)).where(Room.id == room_id)
+    )
+    room = result.scalar_one_or_none()
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+    return {
+        "id": room.id,
+        "name": room.name,
+        "area_id": room.area_id,
+        "area_name": room.area.name if room.area else "",
+    }

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -2,6 +2,41 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+# ── Area / Room schemas ────────────────────────────────────────────
+
+
+class RoomRead(BaseModel):
+    id: int
+    name: str
+    area_id: int
+    area_name: str = ""
+
+    model_config = {"from_attributes": True}
+
+
+class RoomDetailRead(BaseModel):
+    id: int
+    name: str
+    area_id: int
+    area_name: str = ""
+
+    model_config = {"from_attributes": True}
+
+
+class AreaRead(BaseModel):
+    id: int
+    name: str
+
+    model_config = {"from_attributes": True}
+
+
+class AreaDetailRead(BaseModel):
+    id: int
+    name: str
+    rooms: list[RoomRead] = []
+
+    model_config = {"from_attributes": True}
+
 
 class BladeRead(BaseModel):
     id: int
@@ -176,6 +211,7 @@ class KeyRead(BaseModel):
     name: str
     area: str = ""
     room: str = ""
+    room_id: int | None = None
     source: str = ""
     locations_used: str = ""
 
@@ -187,6 +223,7 @@ class SigilRead(BaseModel):
     name: str
     area: str = ""
     room: str = ""
+    room_id: int | None = None
     source: str = ""
     door_unlocks: str = ""
 
@@ -199,6 +236,7 @@ class GrimoireRead(BaseModel):
     spell_name: str = ""
     area: str = ""
     room: str = ""
+    room_id: int | None = None
     source: str = ""
     drop_rate: str = ""
     repeatable: bool = False
@@ -272,6 +310,7 @@ class WorkshopRead(BaseModel):
     id: int
     name: str
     area: str = ""
+    room_id: int | None = None
     available_materials: str = ""
     description: str = ""
 
@@ -393,6 +432,7 @@ class ChestListRead(BaseModel):
     id: int
     area: str
     room: str
+    room_id: int | None = None
     lock_type: str | None = None
 
     model_config = {"from_attributes": True}
@@ -402,6 +442,7 @@ class ChestRead(BaseModel):
     id: int
     area: str
     room: str
+    room_id: int | None = None
     lock_type: str | None = None
     items: list[ChestItemRead] = []
 


### PR DESCRIPTION
## Summary
- Add `areas` and `rooms` as first-class database tables with REST API endpoints
- Migration creates 24 areas and 111 rooms, extracted from chests, grimoires, sigils, keys, and workshops data
- Add `room_id` FK to chests, grimoires, sigils, keys, and workshops tables (populated via migration)
- Normalize "Town Centre" to "Town Center" during data migration
- Old area/room string columns kept for backwards compatibility

## New Endpoints
- `GET /areas` — list all areas
- `GET /areas/{id}` — area detail with rooms
- `GET /rooms` — list all rooms (supports `?area=` filter)
- `GET /rooms/{id}` — room detail with area name

## Updated Endpoints
- Chests, grimoires, sigils, keys, workshops now include `room_id` in responses

## Test plan
- [ ] Verify `GET /areas` returns 24 areas
- [ ] Verify `GET /areas/1` returns area with rooms list
- [ ] Verify `GET /rooms?area=1` filters correctly
- [ ] Verify `GET /rooms/1` returns room with area_name
- [ ] Verify existing endpoints (chests, grimoires, sigils, keys, workshops) still work and include room_id
- [ ] Verify migration populates room_id for all existing rows (8/9 keys, 1 has no matching area)