### PR TITLE
feat: add equip_slot to inventory items

### DIFF
--- a/alembic/versions/b1c2d3e4f5a6_add_equip_slot_to_inventory_items.py
+++ b/alembic/versions/b1c2d3e4f5a6_add_equip_slot_to_inventory_items.py
@@ -1,0 +1,29 @@
+"""add equip_slot to inventory_items
+
+Revision ID: b1c2d3e4f5a6
+Revises: a7b8c9d0e1f2
+Create Date: 2026-03-21 17:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"
+down_revision: str | Sequence[str] | None = "a7b8c9d0e1f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add equip_slot column to inventory_items."""
+    op.add_column("inventory_items", sa.Column("equip_slot", sa.String(20), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove equip_slot column from inventory_items."""
+    op.drop_column("inventory_items", "equip_slot")

--- a/app/models/inventory.py
+++ b/app/models/inventory.py
@@ -36,6 +36,7 @@ class InventoryItem(Base):
     gem_1_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     gem_2_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     gem_3_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    equip_slot: Mapped[str | None] = mapped_column(String(20), nullable=True)
     quantity: Mapped[int] = mapped_column(Integer, server_default="1")
 
     inventory: Mapped["Inventory"] = relationship(back_populates="items")

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -17,6 +17,8 @@ from app.schemas.game_data import (
 
 router = APIRouter(prefix="/user/inventories", tags=["user"])
 
+VALID_EQUIP_SLOTS = {"right_hand", "left_hand", "head", "body", "legs", "arms", "accessory"}
+
 
 async def _get_user_inventory(
     inventory_id: int,
@@ -99,6 +101,26 @@ async def add_item(
     session: AsyncSession = Depends(get_async_session),
 ):
     await _get_user_inventory(inventory_id, user_id, session)
+
+    if body.equip_slot is not None:
+        if body.equip_slot not in VALID_EQUIP_SLOTS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid equip_slot. Must be one of: {', '.join(sorted(VALID_EQUIP_SLOTS))}",
+            )
+        # Check that the slot is not already occupied in this inventory
+        existing = await session.execute(
+            select(InventoryItem).where(
+                InventoryItem.inventory_id == inventory_id,
+                InventoryItem.equip_slot == body.equip_slot,
+            )
+        )
+        if existing.scalar_one_or_none():
+            raise HTTPException(
+                status_code=400,
+                detail=f"Equip slot '{body.equip_slot}' is already occupied",
+            )
+
     item = InventoryItem(inventory_id=inventory_id, **body.model_dump())
     session.add(item)
     await session.commit()
@@ -124,7 +146,30 @@ async def update_item(
     item = result.scalar_one_or_none()
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
+
     update_data = body.model_dump(exclude_unset=True)
+
+    if "equip_slot" in update_data and update_data["equip_slot"] is not None:
+        slot = update_data["equip_slot"]
+        if slot not in VALID_EQUIP_SLOTS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid equip_slot. Must be one of: {', '.join(sorted(VALID_EQUIP_SLOTS))}",
+            )
+        # Check that the slot is not already occupied by another item
+        existing = await session.execute(
+            select(InventoryItem).where(
+                InventoryItem.inventory_id == inventory_id,
+                InventoryItem.equip_slot == slot,
+                InventoryItem.id != item_id,
+            )
+        )
+        if existing.scalar_one_or_none():
+            raise HTTPException(
+                status_code=400,
+                detail=f"Equip slot '{slot}' is already occupied",
+            )
+
     for field, value in update_data.items():
         setattr(item, field, value)
     await session.commit()

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -355,6 +355,7 @@ class InventoryItemCreate(BaseModel):
     gem_1_id: int | None = None
     gem_2_id: int | None = None
     gem_3_id: int | None = None
+    equip_slot: str | None = None
     quantity: int = 1
 
 
@@ -368,6 +369,7 @@ class InventoryItemRead(BaseModel):
     gem_1_id: int | None = None
     gem_2_id: int | None = None
     gem_3_id: int | None = None
+    equip_slot: str | None = None
     quantity: int = 1
 
     model_config = {"from_attributes": True}
@@ -381,6 +383,7 @@ class InventoryItemUpdate(BaseModel):
     gem_1_id: int | None = None
     gem_2_id: int | None = None
     gem_3_id: int | None = None
+    equip_slot: str | None = None
     quantity: int | None = None
 
 


### PR DESCRIPTION
## Summary
- Add `equip_slot` column to `inventory_items` table (nullable String(20)) via Alembic migration
- Update `InventoryItem` model and all related Pydantic schemas (Create/Read/Update)
- Add validation in create/update item endpoints: valid slot values only, no duplicate slots per inventory

Valid slots: `right_hand`, `left_hand`, `head`, `body`, `legs`, `arms`, `accessory`. Null means item is in the bag (unequipped).

## Test plan
- [x] `ruff check` and `ruff format` pass
- [x] All 8 existing tests pass
- [ ] Verify migration applies cleanly on production DB
- [ ] Test creating items with equip_slot via API
- [ ] Test that duplicate slot assignment returns 400