### PR TITLE
feat: add storage field to inventory items

### DIFF
--- a/alembic/versions/c2d3e4f5a6b7_add_storage_to_inventory_items.py
+++ b/alembic/versions/c2d3e4f5a6b7_add_storage_to_inventory_items.py
@@ -1,0 +1,32 @@
+"""add storage to inventory_items
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-03-23 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c2d3e4f5a6b7"
+down_revision: str | Sequence[str] | None = "b1c2d3e4f5a6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add storage column to inventory_items, defaulting to 'bag'."""
+    op.add_column(
+        "inventory_items",
+        sa.Column("storage", sa.String(20), server_default="bag", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Remove storage column from inventory_items."""
+    op.drop_column("inventory_items", "storage")

--- a/app/models/inventory.py
+++ b/app/models/inventory.py
@@ -37,6 +37,7 @@ class InventoryItem(Base):
     gem_2_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     gem_3_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     equip_slot: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    storage: Mapped[str] = mapped_column(String(20), server_default="bag")
     quantity: Mapped[int] = mapped_column(Integer, server_default="1")
 
     inventory: Mapped["Inventory"] = relationship(back_populates="items")

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -19,6 +19,7 @@ from app.schemas.game_data import (
 router = APIRouter(prefix="/user/inventories", tags=["user"])
 
 VALID_EQUIP_SLOTS = {"right_hand", "left_hand", "head", "body", "legs", "arms", "accessory"}
+VALID_STORAGE = {"bag", "container"}
 
 
 async def _get_user_inventory(
@@ -103,10 +104,20 @@ async def import_items(
 ):
     inventory = await _get_user_inventory(inventory_id, user_id, session)
 
-    # Validate equip_slots and check for duplicates within the import batch
+    # Validate storage and equip_slots, check for duplicates within the import batch
     seen_slots: set[str] = set()
     for item_data in body.items:
+        if item_data.storage not in VALID_STORAGE:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid storage. Must be one of: {', '.join(sorted(VALID_STORAGE))}",
+            )
         if item_data.equip_slot is not None:
+            if item_data.storage != "bag":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Items with equip_slot must have storage 'bag'",
+                )
             if item_data.equip_slot not in VALID_EQUIP_SLOTS:
                 raise HTTPException(
                     status_code=400,
@@ -157,7 +168,18 @@ async def add_item(
 ):
     await _get_user_inventory(inventory_id, user_id, session)
 
+    if body.storage not in VALID_STORAGE:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid storage. Must be one of: {', '.join(sorted(VALID_STORAGE))}",
+        )
+
     if body.equip_slot is not None:
+        if body.storage != "bag":
+            raise HTTPException(
+                status_code=400,
+                detail="Items with equip_slot must have storage 'bag'",
+            )
         if body.equip_slot not in VALID_EQUIP_SLOTS:
             raise HTTPException(
                 status_code=400,
@@ -203,6 +225,22 @@ async def update_item(
         raise HTTPException(status_code=404, detail="Item not found")
 
     update_data = body.model_dump(exclude_unset=True)
+
+    if "storage" in update_data and update_data["storage"] is not None:
+        if update_data["storage"] not in VALID_STORAGE:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid storage. Must be one of: {', '.join(sorted(VALID_STORAGE))}",
+            )
+
+    # Determine effective storage after update
+    effective_storage = update_data.get("storage", item.storage)
+    effective_equip_slot = update_data.get("equip_slot", item.equip_slot)
+    if effective_equip_slot is not None and effective_storage != "bag":
+        raise HTTPException(
+            status_code=400,
+            detail="Items with equip_slot must have storage 'bag'",
+        )
 
     if "equip_slot" in update_data and update_data["equip_slot"] is not None:
         slot = update_data["equip_slot"]

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -356,6 +356,7 @@ class InventoryItemCreate(BaseModel):
     gem_2_id: int | None = None
     gem_3_id: int | None = None
     equip_slot: str | None = None
+    storage: str = "bag"
     quantity: int = 1
 
 
@@ -370,6 +371,7 @@ class InventoryItemRead(BaseModel):
     gem_2_id: int | None = None
     gem_3_id: int | None = None
     equip_slot: str | None = None
+    storage: str = "bag"
     quantity: int = 1
 
     model_config = {"from_attributes": True}
@@ -384,6 +386,7 @@ class InventoryItemUpdate(BaseModel):
     gem_2_id: int | None = None
     gem_3_id: int | None = None
     equip_slot: str | None = None
+    storage: str | None = None
     quantity: int | None = None
 
 


### PR DESCRIPTION
## Summary
- Adds `storage` column to `inventory_items` table (`bag` | `container`, default `bag`)
- Mirrors the game's dual inventory: active bag vs workshop container
- Validates that `equip_slot` requires `storage = "bag"` (can't equip from container)
- Alembic migration uses `server_default` so existing rows get `bag` automatically

## Test plan
- [ ] Run migration on local DB
- [ ] Verify existing items default to `storage = "bag"`
- [ ] POST item with `storage: "container"` succeeds
- [ ] POST item with `equip_slot` + `storage: "container"` returns 400
- [ ] Import endpoint validates storage per item