### PR TITLE
feat: DP/PP in save import and inventory responses

### DIFF
--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -200,6 +200,10 @@ async def import_save(
                 equip_slot=equip_slot,
                 storage=item_data.storage,
                 quantity=item_data.quantity,
+                dp_current=item_data.dp_current,
+                dp_max=item_data.dp_max,
+                pp_current=item_data.pp_current,
+                pp_max=item_data.pp_max,
             )
         )
 

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -475,6 +475,10 @@ class InventoryItemRead(BaseModel):
     equip_slot: str | None = None
     storage: str = "bag"
     quantity: int = 1
+    dp_current: int | None = None
+    dp_max: int | None = None
+    pp_current: int | None = None
+    pp_max: int | None = None
 
     model_config = {"from_attributes": True}
 
@@ -550,6 +554,10 @@ class GameSaveImportItem(BaseModel):
     equip_slot: str | None = None
     storage: str = "bag"
     quantity: int = 1
+    dp_current: int | None = None
+    dp_max: int | None = None
+    pp_current: int | None = None
+    pp_max: int | None = None
 
 
 class GameSaveImportRequest(BaseModel):


### PR DESCRIPTION
## Summary
- Add dp_current/dp_max/pp_current/pp_max to GameSaveImportItem
- Store DP/PP from save imports on InventoryItem records
- Return DP/PP in InventoryItemRead responses
- Scorer uses DP/PP for attack modifier calculation