### PR TITLE
feat: JWT issuer validation, loadout rate limiting, and database SSL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
 # Database
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/vagrant_story
+DATABASE_REQUIRE_SSL=false
 
 # Environment
 ENVIRONMENT=development
+
+# Auth
+AUTH_TOKEN_ISSUER=
 
 # CORS
 CORS_ORIGINS=

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -5,10 +5,19 @@ import structlog
 from fastapi import HTTPException, Request
 
 from app.auth.jwks import get_public_key
+from app.config import settings
 
 logger = structlog.get_logger("app.auth")
 
 TOKEN_AUDIENCE = ["fastapi-users:auth"]
+
+
+def _decode_kwargs() -> dict:
+    """Build common kwargs for jwt.decode(), including issuer if configured."""
+    kwargs: dict = {"algorithms": ["RS256"], "audience": TOKEN_AUDIENCE}
+    if settings.auth_token_issuer:
+        kwargs["issuer"] = settings.auth_token_issuer
+    return kwargs
 
 
 async def get_current_user(request: Request) -> str:
@@ -18,25 +27,16 @@ async def get_current_user(request: Request) -> str:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
     public_key = await get_public_key()
+    decode_kwargs = _decode_kwargs()
 
     try:
-        payload = jwt.decode(
-            token,
-            key=public_key,
-            algorithms=["RS256"],
-            audience=TOKEN_AUDIENCE,
-        )
+        payload = jwt.decode(token, key=public_key, **decode_kwargs)
     except jwt.exceptions.InvalidSignatureError:
         # Key may have rotated — refresh and retry once
         logger.warning("jwt_signature_invalid", detail="Retrying with refreshed JWKS key")
         public_key = await get_public_key(force_refresh=True)
         try:
-            payload = jwt.decode(
-                token,
-                key=public_key,
-                algorithms=["RS256"],
-                audience=TOKEN_AUDIENCE,
-            )
+            payload = jwt.decode(token, key=public_key, **decode_kwargs)
         except jwt.PyJWTError as e:
             logger.warning("jwt_verify_failed_after_refresh", error=str(e))
             raise HTTPException(status_code=401, detail="Invalid token") from e

--- a/app/config.py
+++ b/app/config.py
@@ -10,6 +10,8 @@ class Settings(BaseSettings):
     cors_origins: str = ""
     log_level: str = "INFO"
     auth_jwks_url: str = "https://auth-api.criticalbit.gg/auth/jwks"
+    auth_token_issuer: str = ""
+    database_require_ssl: bool = False
 
     @property
     def is_development(self) -> bool:

--- a/app/database.py
+++ b/app/database.py
@@ -12,9 +12,14 @@ class Base(DeclarativeBase):
     pass
 
 
+_connect_args: dict = {}
+if settings.database_require_ssl:
+    _connect_args["ssl"] = "require"
+
 engine = create_async_engine(
     settings.database_url,
     echo=settings.is_development,
+    connect_args=_connect_args,
 )
 
 async_session_maker = async_sessionmaker(

--- a/app/main.py
+++ b/app/main.py
@@ -5,12 +5,12 @@ import structlog
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from scalar_fastapi import get_scalar_api_reference
-from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 
 from app.config import settings
 from app.logging import setup_logging
+from app.rate_limit import limiter
 from app.routers import (
     areas_router,
     armor_router,
@@ -57,7 +57,6 @@ app.add_middleware(
     allow_headers=["Content-Type"],
 )
 
-limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 

--- a/app/rate_limit.py
+++ b/app/rate_limit.py
@@ -1,0 +1,4 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/app/routers/loadout.py
+++ b/app/routers/loadout.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,6 +11,7 @@ from app.models.gem import Gem
 from app.models.grip import Grip
 from app.models.inventory import Inventory, InventoryItem
 from app.models.material import Material
+from app.rate_limit import limiter
 from app.schemas.game_data import (
     LoadoutArmor,
     LoadoutBodyPartScore,
@@ -28,20 +29,22 @@ router = APIRouter(prefix="/loadout", tags=["loadout"])
 
 
 @router.post("", response_model=LoadoutResponse)
+@limiter.limit("10/minute")
 async def optimize_loadout_endpoint(
-    request: LoadoutRequest,
+    request: Request,
+    body: LoadoutRequest,
     user_id: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session),
 ):
     """Find the best equipment loadout from an inventory to fight a specific enemy."""
     # Validate mode
-    if request.mode not in ("full", "offense", "defense"):
+    if body.mode not in ("full", "offense", "defense"):
         raise HTTPException(status_code=400, detail="Mode must be 'full', 'offense', or 'defense'")
 
     # Fetch inventory (verify ownership)
     inv_result = await session.execute(
         select(Inventory).where(
-            Inventory.id == request.inventory_id,
+            Inventory.id == body.inventory_id,
             Inventory.user_id == user_id,
         )
     )
@@ -50,23 +53,23 @@ async def optimize_loadout_endpoint(
         raise HTTPException(status_code=404, detail="Inventory not found")
 
     # Fetch enemy with body parts (selectin is the default lazy strategy)
-    enemy_result = await session.execute(select(Enemy).where(Enemy.id == request.enemy_id))
+    enemy_result = await session.execute(select(Enemy).where(Enemy.id == body.enemy_id))
     enemy = enemy_result.scalar_one_or_none()
     if not enemy:
         raise HTTPException(status_code=404, detail="Enemy not found")
 
     # Filter inventory items by storage preferences
     allowed_storage: set[str] = set()
-    if request.include_bag:
+    if body.include_bag:
         allowed_storage.add("bag")
-    if request.include_container:
+    if body.include_container:
         allowed_storage.add("container")
 
     filtered_items: list[InventoryItem] = []
     for item in inventory.items:
         if item.storage in allowed_storage:
             # If include_equipped is False, skip items that have an equip_slot
-            if not request.include_equipped and item.equip_slot is not None:
+            if not body.include_equipped and item.equip_slot is not None:
                 continue
             filtered_items.append(item)
 
@@ -98,10 +101,10 @@ async def optimize_loadout_endpoint(
     gems_result = await session.execute(select(Gem))
     gems_db = {g.id: g for g in gems_result.scalars().all()}
 
-    # Resolve player stats: request overrides > inventory base stats > 0
-    player_str = request.player_str if request.player_str is not None else (inventory.base_str or 0)
-    player_int = request.player_int if request.player_int is not None else (inventory.base_int or 0)
-    player_agi = request.player_agi if request.player_agi is not None else (inventory.base_agi or 0)
+    # Resolve player stats: body overrides > inventory base stats > 0
+    player_str = body.player_str if body.player_str is not None else (inventory.base_str or 0)
+    player_int = body.player_int if body.player_int is not None else (inventory.base_int or 0)
+    player_agi = body.player_agi if body.player_agi is not None else (inventory.base_agi or 0)
 
     # Run optimizer
     loadouts = optimize_loadout(
@@ -112,8 +115,8 @@ async def optimize_loadout_endpoint(
         armor_db=armor_db,
         materials_db=materials_db,
         gems_db=gems_db,
-        mode=request.mode,
-        include_2h=request.include_2h,
+        mode=body.mode,
+        include_2h=body.include_2h,
         player_str=player_str,
         player_int=player_int,
         player_agi=player_agi,


### PR DESCRIPTION
## Summary
- **JWT issuer validation**: New `AUTH_TOKEN_ISSUER` env var — when set, `jwt.decode()` validates the `iss` claim against it. Defaults to empty (skipped) for backward compatibility.
- **Loadout rate limiting**: `POST /loadout` now rate-limited to 10 requests/minute per IP via slowapi. Extracted limiter to `app/rate_limit.py` to avoid circular imports.
- **Database SSL**: New `DATABASE_REQUIRE_SSL` env var — when `true`, passes `ssl="require"` to asyncpg so connections fail if SSL is unavailable. Defaults to `false`.

All three features are opt-in via env vars, so this is safe to deploy before updating Railway config.

## Production env vars to set after merge
```
AUTH_TOKEN_ISSUER=<check a real JWT's iss claim first>
DATABASE_REQUIRE_SSL=true
```

## Test plan
- [x] All 13 existing tests pass
- [x] Ruff lint and format pass
- [x] Dev server starts cleanly (no SSL, no issuer — defaults unchanged)
- [ ] After merge: set `DATABASE_REQUIRE_SSL=true` in Railway and verify API connects
- [ ] After merge: inspect a real JWT's `iss` claim, then set `AUTH_TOKEN_ISSUER` in Railway