### PR TITLE
chore(security): API hardening — CI permissions, request limits, input validation, audit logging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,1 @@
-# Require review for auth changes
-/app/auth/ @amrtgaber
-/app/config.py @amrtgaber
-
-# Require review for CI/CD changes
-/.github/ @amrtgaber
-
-# Require review for database migrations
-/alembic/ @amrtgaber
-
-# Require review for deployment config
-/Dockerfile @amrtgaber
-/start.sh @amrtgaber
+* @amrtgaber

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Require review for auth changes
+/app/auth/ @amrtgaber
+/app/config.py @amrtgaber
+
+# Require review for CI/CD changes
+/.github/ @amrtgaber
+
+# Require review for database migrations
+/alembic/ @amrtgaber
+
+# Require review for deployment config
+/Dockerfile @amrtgaber
+/start.sh @amrtgaber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -2,6 +2,7 @@
 
 import jwt
 import structlog
+import structlog.contextvars
 from fastapi import HTTPException, Request
 
 from app.auth.jwks import get_public_key
@@ -48,4 +49,5 @@ async def get_current_user(request: Request) -> str:
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid token: missing subject")
 
+    structlog.contextvars.bind_contextvars(user_id=user_id)
     return user_id

--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,17 @@ app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 
+MAX_REQUEST_BODY_SIZE = 1_048_576  # 1 MB
+
+
+@app.middleware("http")
+async def limit_request_size(request: Request, call_next) -> Response:
+    content_length = request.headers.get("content-length")
+    if content_length and int(content_length) > MAX_REQUEST_BODY_SIZE:
+        return Response(content="Request body too large", status_code=413)
+    return await call_next(request)
+
+
 @app.middleware("http")
 async def add_cache_headers(request: Request, call_next) -> Response:
     response = await call_next(request)

--- a/app/schemas/game_data.py
+++ b/app/schemas/game_data.py
@@ -497,7 +497,7 @@ class InventoryItemUpdate(BaseModel):
 
 
 class InventoryImportRequest(BaseModel):
-    items: list[InventoryItemCreate]
+    items: list[InventoryItemCreate] = Field(max_length=500)
     clear_existing: bool = False
     base_hp: int | None = None
     base_mp: int | None = None
@@ -507,11 +507,11 @@ class InventoryImportRequest(BaseModel):
 
 
 class InventoryCreate(BaseModel):
-    name: str
+    name: str = Field(min_length=1, max_length=100)
 
 
 class InventoryUpdate(BaseModel):
-    name: str
+    name: str = Field(min_length=1, max_length=100)
 
 
 class InventoryListRead(BaseModel):
@@ -568,8 +568,8 @@ class GameSaveImportRequest(BaseModel):
     using stable game data identifiers.
     """
 
-    name: str
-    items: list[GameSaveImportItem]
+    name: str = Field(min_length=1, max_length=100)
+    items: list[GameSaveImportItem] = Field(max_length=500)
     base_hp: int | None = None
     base_mp: int | None = None
     base_str: int | None = None


### PR DESCRIPTION
## Summary

Several API security items from a recent security audit, bundled into one PR since they're all small and scoped to security hardening:

- **CI least-privilege**: Add `permissions: contents: read` block to the CI workflow so the default `GITHUB_TOKEN` has minimal scope (matches what's already on vagrant-story-web CI).
- **Request body size limit**: Add a 1MB `Content-Length` check middleware in `app/main.py`. The largest legitimate payload (save file import with up to 500 items) is well under 100KB, so 1MB is generous.
- **Input validation**: Add `Field(min_length=1, max_length=100)` to inventory names in `InventoryCreate`, `InventoryUpdate`, and `GameSaveImportRequest`. Cap `items` arrays at 500 entries in `InventoryImportRequest` and `GameSaveImportRequest`.
- **Audit logging**: Bind `user_id` to structlog contextvars in the auth dependency. Once a request is authenticated, every subsequent log line in that request automatically carries the user_id without needing to thread it through every handler. The existing request logging middleware already emits `duration_ms`, `method`, `path`, `status_code` — this just enriches those logs with the caller.
- **CODEOWNERS**: Add a file scoping auth, config, CI, migrations, and deploy paths to @amrtgaber so PRs to critical paths require explicit review.

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run pytest` — 13 tests pass
- [ ] CI passes
- [ ] Post-merge: hit POST /loadout with a body > 1MB and verify 413 response
- [ ] Post-merge: verify a real request log line in Cloud Logging shows `user_id` bound