### PR TITLE
chore: remove stale railway.toml after GCP migration

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,2 +1,0 @@
-[build]
-dockerfilePath = "Dockerfile"


### PR DESCRIPTION
## Summary
- Deletes `railway.toml`, a 2-line config file left behind from the Railway deploy era. It has zero references anywhere else in the codebase and was only used by Railway's build system to force Docker builds over Nixpacks.
- Cloud Run (added in #63) uses the Dockerfile directly and ignores this file entirely.

## Test plan
- [x] Grep confirmed no other files in the repo reference `railway` (case-insensitive) or any `RAILWAY_*` env vars.
- [ ] CI passes (no code paths touched, so nothing functional to regress).