### PR TITLE
feat(observability): add Sentry error tracking to FastAPI service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ CORS_ORIGINS=
 
 # Logging
 LOG_LEVEL=INFO
+
+# Sentry error tracking
+# Leave SENTRY_DSN unset in dev to skip Sentry init entirely.
+# Set in Cloud Run via `gcloud run services update ... --update-env-vars SENTRY_DSN=...`
+# for production. Distributed tracing works across frontend and backend projects
+# within the same Sentry organization.
+SENTRY_DSN=

--- a/app/config.py
+++ b/app/config.py
@@ -12,10 +12,15 @@ class Settings(BaseSettings):
     auth_jwks_url: str = "https://auth-api.criticalbit.gg/auth/jwks"
     auth_token_issuer: str = ""
     database_require_ssl: bool = False
+    sentry_dsn: str = ""
 
     @property
     def is_development(self) -> bool:
         return self.environment == "development"
+
+    @property
+    def sentry_traces_sample_rate(self) -> float:
+        return 1.0 if self.is_development else 0.1
 
     @property
     def cors_origin_list(self) -> list[str]:

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from slowapi.errors import RateLimitExceeded
 
 from app.config import settings
 from app.logging import setup_logging
+from app.observability.sentry import init_sentry
 from app.rate_limit import limiter
 from app.routers import (
     areas_router,
@@ -38,6 +39,7 @@ from app.routers import (
     workshops_router,
 )
 
+init_sentry()
 setup_logging()
 logger = structlog.get_logger("app.request")
 
@@ -54,7 +56,7 @@ app.add_middleware(
     allow_origin_regex=settings.cors_origin_regex,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allow_headers=["Content-Type"],
+    allow_headers=["Content-Type", "sentry-trace", "baggage"],
 )
 
 app.state.limiter = limiter

--- a/app/observability/sentry.py
+++ b/app/observability/sentry.py
@@ -1,0 +1,29 @@
+"""Sentry SDK initialization for the FastAPI service.
+
+Init must run BEFORE FastAPI() is constructed so FastApiIntegration and
+StarletteIntegration can auto-instrument middleware. See app/main.py.
+"""
+
+import sentry_sdk
+
+from app.config import settings
+
+
+def init_sentry() -> None:
+    if not settings.sentry_dsn:
+        return
+
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.environment,
+        # Kept false until a public privacy policy ships. Matches the
+        # frontend's cookie-free posture so distributed traces aren't
+        # leaking PII on one side while hiding it on the other.
+        send_default_pii=False,
+        traces_sample_rate=settings.sentry_traces_sample_rate,
+        # Continuous profiling tied to active spans. Effective profile
+        # rate = traces_sample_rate * 1.0, so dev 1.0 / prod 0.1.
+        profile_session_sample_rate=1.0,
+        profile_lifecycle="trace",
+        enable_logs=True,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "slowapi>=0.1.9",
     "limits>=5.8.0",
     "structlog>=25.0.0",
+    "sentry-sdk[fastapi]>=2.35.0",
     "scalar-fastapi>=1.8.1",
     "pyjwt>=2.12.1",
     "cryptography>=46.0.5",

--- a/uv.lock
+++ b/uv.lock
@@ -815,6 +815,24 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.57.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/87/46c0406d8b5ddd026f73adaf5ab75ce144219c41a4830b52df4b9ab55f7f/sentry_sdk-2.57.0.tar.gz", hash = "sha256:4be8d1e71c32fb27f79c577a337ac8912137bba4bcbc64a4ec1da4d6d8dc5199", size = 435288, upload-time = "2026-03-31T09:39:29.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/64/982e07b93219cb52e1cca5d272cb579e2f3eb001956c9e7a9a6d106c9473/sentry_sdk-2.57.0-py2.py3-none-any.whl", hash = "sha256:812c8bf5ff3d2f0e89c82f5ce80ab3a6423e102729c4706af7413fd1eb480585", size = 456489, upload-time = "2026-03-31T09:39:27.524Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
+[[package]]
 name = "slowapi"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
@@ -916,6 +934,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
@@ -986,6 +1013,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "scalar-fastapi" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "structlog" },
@@ -1014,6 +1042,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.13.0" },
     { name = "pyjwt", specifier = ">=2.12.1" },
     { name = "scalar-fastapi", specifier = ">=1.8.1" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.35.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", specifier = ">=2.0.48" },
     { name = "structlog", specifier = ">=25.0.0" },


### PR DESCRIPTION
## Summary
Wires `sentry-sdk[fastapi]` into the FastAPI service so the backend captures errors and participates in distributed traces initiated from the frontend. Paired with the already-open frontend PR (#135 on vagrant-story-web).

**What's included:**
- `sentry-sdk[fastapi]>=2.35.0` added to dependencies (actual installed: 2.57.0, well above the minimum)
- New `app/observability/sentry.py` module — gated on `SENTRY_DSN` being set, so local dev and tests run without sending telemetry
- `init_sentry()` is called as the **very first runtime statement** in `app/main.py`, before `setup_logging()` and before `app = FastAPI(...)`. Per Sentry's Python SDK SKILL: \"StarletteIntegration + FastApiIntegration are auto-enabled together and require init to precede app construction for middleware instrumentation.\"
- `sentry_dsn` added to `app/config.py` Settings class following the existing pydantic-settings convention. `sentry_traces_sample_rate` computed as a property that returns 1.0 in dev, 0.1 in prod based on the existing `is_development` check.
- `.env.example` documents the new `SENTRY_DSN` var
- Continuous profiling enabled with `profile_lifecycle=\"trace\"` — profiling is tied to active spans, so effective profile rate is `traces_sample_rate × 1.0` = dev 1.0 / prod 0.1

## :warning: Critical CORS fix bundled in

`app/main.py:57` had `allow_headers=[\"Content-Type\"]`, which would block the frontend's Sentry `sentry-trace` and `baggage` headers via CORS preflight, breaking all production API calls from any user running the frontend PR #135 bundle. Added both to the allowlist.

**This is a hard blocker for merging the frontend Sentry PR.** Merge order must be:
1. ✅ This PR merges → GitHub Actions deploys to Cloud Run → new CORS is live
2. ⏳ Frontend PR #135 merges → Netlify deploys → users get new bundle with distributed tracing
3. ❌ Reversing the order = broken production for any user with the new frontend bundle

## Deliberate deviations from SKILL.md defaults

| SKILL recommends | This PR uses | Why |
|---|---|---|
| `send_default_pii=True` | `False` | Matches the frontend's cookie-free PostHog posture. No public privacy policy is shipped; distributed traces would leak PII on one side while hiding it on the other. One-line change once a privacy page is live. |
| `traces_sample_rate=1.0` | `0.1` in prod, `1.0` in dev | SKILL itself recommends lowering for production traffic. 0.1 stays well within Sentry's free-tier performance unit quota. |
| `LoggingIntegration` with explicit structlog bridging | Nothing extra required | `app/logging.py` already uses `structlog.stdlib.LoggerFactory()` which routes structlog through Python stdlib. Sentry's LoggingIntegration auto-captures stdlib logger output. The existing `request_id` contextvar gets attached to Sentry events as a tag automatically. Structlog bridging is a non-issue. |

## Production deployment status

- [x] `SENTRY_DSN` already set on Cloud Run via `gcloud run services update vagrant-story-api --region=us-east1 --update-env-vars SENTRY_DSN=...` (revision `vagrant-story-api-00009-5k6`). The value is sitting there unused until this PR deploys, because the currently-running old image has no code that reads `settings.sentry_dsn`.
- [x] Cloud Run environment remains `production` via the existing `ENVIRONMENT=production` env var — reused by the new `sentry_sdk.init(environment=...)` call, no separate SENTRY_ENVIRONMENT needed.
- [x] Sentry project created: `critical-bit.sentry.io/projects/vagrant-story-api/` (separate project from frontend so Python-specific UI, quota isolation, and alert rules can be tuned independently; distributed tracing still connects across projects within the same org)

## Test plan
- [x] `uv run ruff check .` passes (0 issues)
- [x] `uv run pytest` passes (13/13)
- [x] Test suite imports `app.main` which calls `init_sentry()` — verified it no-ops correctly when `SENTRY_DSN` is unset
- [ ] Post-merge: verify first production event lands in the vagrant-story-api Sentry project (trigger with `curl https://vagrant-story-api.criticalbit.gg/<nonexistent-endpoint>` or wait for a real error)
- [ ] Post-merge: verify distributed tracing — a frontend request should produce a single trace in Sentry with both frontend and backend spans stitched together

## Follow-up work
- **Release tracking** — Cloud Run runtime env vars don't naturally map to git SHAs. Proper fix requires adding a `COMMIT_SHA` Docker build arg to the Dockerfile, passing `${{ github.sha }}` from `.github/workflows/deploy.yml`, and reading it via a `SENTRY_RELEASE` env var at runtime. Deferred to keep this PR focused.
- **Secret Manager migration for `SENTRY_DSN`** (optional) — would match the existing pattern used for `DATABASE_URL` which sources from the `vs-db-url` secret. DSNs are less sensitive than DB creds (designed to be embeddable in client code), so plain env var is acceptable initially.