### PR TITLE
feat(observability): tie Sentry release to git SHA via Docker build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ LOG_LEVEL=INFO
 # for production. Distributed tracing works across frontend and backend projects
 # within the same Sentry organization.
 SENTRY_DSN=
+
+# SENTRY_RELEASE is injected at Docker build time from the git SHA via the
+# COMMIT_SHA build arg in Dockerfile + .github/workflows/deploy.yml. Leave
+# unset for local dev (events will have no release tag).
+SENTRY_RELEASE=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,10 +38,16 @@ jobs:
       - run: gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
 
       - name: Build and push
+        env:
+          IMAGE: ${{ env.IMAGE }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          docker build -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
-          docker push ${{ env.IMAGE }}:${{ github.sha }}
-          docker push ${{ env.IMAGE }}:latest
+          docker build \
+            --build-arg COMMIT_SHA="$COMMIT_SHA" \
+            -t "$IMAGE:$COMMIT_SHA" \
+            -t "$IMAGE:latest" .
+          docker push "$IMAGE:$COMMIT_SHA"
+          docker push "$IMAGE:latest"
 
       - name: Deploy to Cloud Run
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,9 @@ EXPOSE 8000
 COPY start.sh ./
 RUN chmod +x start.sh
 
+# Sentry release version from CI. Positioned last so COMMIT_SHA changes
+# don't invalidate the layer cache for dependency install or code copies.
+ARG COMMIT_SHA=unknown
+ENV SENTRY_RELEASE=$COMMIT_SHA
+
 CMD ["./start.sh"]

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     auth_token_issuer: str = ""
     database_require_ssl: bool = False
     sentry_dsn: str = ""
+    sentry_release: str = ""
 
     @property
     def is_development(self) -> bool:

--- a/app/observability/sentry.py
+++ b/app/observability/sentry.py
@@ -16,6 +16,7 @@ def init_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.sentry_dsn,
         environment=settings.environment,
+        release=settings.sentry_release or None,
         # Kept false until a public privacy policy ships. Matches the
         # frontend's cookie-free posture so distributed traces aren't
         # leaking PII on one side while hiding it on the other.


### PR DESCRIPTION
## Summary
Previously, the API's \`sentry_sdk.init()\` had no \`release=\` argument, so every event flowed into an \"unknown release\" bucket. This PR wires the git commit SHA through the Docker build into a runtime env var, enabling Sentry's regression detection, first-seen / last-seen metadata, and deploy-correlation features.

## How it works
- **\`Dockerfile\`** declares \`ARG COMMIT_SHA\` (default \`unknown\`) and \`ENV SENTRY_RELEASE=\$COMMIT_SHA\`. Positioned as the last instructions so \`COMMIT_SHA\` changes don't invalidate the layer cache for dependency install, code copies, or start script — only the two near-zero-byte ENV/CMD layers get rebuilt per deploy.
- **\`.github/workflows/deploy.yml\`** passes \`--build-arg COMMIT_SHA=\$COMMIT_SHA\` when building the image. The SHA is injected via an \`env:\` block rather than inline \`\${{ github.sha }}\` substitution to follow [GitHub's recommended workflow injection defense pattern](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/). The pre-existing \`\${{ env.IMAGE }}\` reference in the same run block is migrated to the same pattern for consistency.
- **\`app/config.py\`** adds \`sentry_release: str = \"\"\` to the pydantic-settings \`Settings\` class. pydantic-settings reads \`os.environ\` automatically, so setting \`SENTRY_RELEASE\` via the Dockerfile ENV is picked up without any additional wiring.
- **\`app/observability/sentry.py\`** passes \`release=settings.sentry_release or None\` to \`sentry_sdk.init()\`. The \`or None\` converts an empty-string default into Sentry's preferred \"no release\" sentinel — important because passing an empty string as release creates a release called literally \"\" in Sentry's UI.

## Test plan
- [x] \`uv run ruff check .\` passes
- [x] \`uv run pytest\` passes (13/13)
- [x] Local dev still works with \`SENTRY_RELEASE\` unset (release defaults to None, matches pre-PR behavior exactly)
- [ ] Post-merge: verify the next production deploy produces events in Sentry tagged with the merge commit SHA (visit \`critical-bit.sentry.io/releases/\` for the \`vagrant-story-api\` project)
- [ ] Post-merge: trigger a controlled error after deploy, confirm the issue's metadata shows \"First seen in release: <sha>\"

## Cache impact
Before this PR, \`docker build\` without Buildx cache invalidation produced one set of identical-content layers on each commit. With this PR, the \`COMMIT_SHA\` ARG at the bottom of the Dockerfile causes the final two layers to rebuild per commit — both are 0-byte env declarations, so push size and build time are effectively unchanged.

## Follow-up (unrelated)
This completes Phase 1 of the post-Sentry follow-up work. Phase 2 (privacy policy + \`send_default_pii\` flip across both repos) and Phase 3 (consent banner with centralized tracking in \`criticalbit-auth-api\`) are tracked separately.