### PR TITLE
feat(observability): enable send_default_pii now that privacy policy covers it

### DIFF
--- a/app/observability/sentry.py
+++ b/app/observability/sentry.py
@@ -17,10 +17,10 @@ def init_sentry() -> None:
         dsn=settings.sentry_dsn,
         environment=settings.environment,
         release=settings.sentry_release or None,
-        # Kept false until a public privacy policy ships. Matches the
-        # frontend's cookie-free posture so distributed traces aren't
-        # leaking PII on one side while hiding it on the other.
-        send_default_pii=False,
+        # Privacy policy at criticalbit.gg/privacy discloses the data
+        # collected here (IP, headers, request body). Enabled for
+        # debuggability now that users have been given notice.
+        send_default_pii=True,
         traces_sample_rate=settings.sentry_traces_sample_rate,
         # Continuous profiling tied to active spans. Effective profile
         # rate = traces_sample_rate * 1.0, so dev 1.0 / prod 0.1.


### PR DESCRIPTION
## Summary
Flips \`send_default_pii\` from \`False\` to \`True\` in \`app/observability/sentry.py\`. This attaches client IP address, request headers, and request body data to Sentry events, significantly improving debuggability by letting us see exactly which user, browser, request state, and network context produced each error.

**Phase 2, part 2 of 3** in the Sentry observability rollout.

## Prerequisite (already met)
This PR can only merge after the centralized privacy policy at \`criticalbit.gg/privacy\` has been updated to disclose the new data collection, so users have notice before more data is collected. That update landed in [criticalbit-web PR #11](https://github.com/ag-tech-group/criticalbit-web/pull/11) as commit \`8550911\` and is live in production:

- ✅ Bundle hash changed, \`AG Technology Group\` string present in production bundle
- ✅ New sections (Sentry disclosure, Your rights, International transfers, Children's privacy, operator identification) all deployed

## What this actually changes in event data

Before (\`send_default_pii=False\`):
- Error message, stack trace
- Transaction name, release, environment
- Breadcrumbs (non-PII application events)

After (\`send_default_pii=True\`, this PR):
- Everything above, PLUS:
- Client IP address
- Request headers (including \`User-Agent\`, \`X-Forwarded-For\`, \`Referer\`)
- Authenticated user id/email (from FastAPI-Users integration, if available via JWT claims)
- Request body for POST/PUT/PATCH (subject to the existing 1MB limit middleware in \`main.py:64\`)

All of the above is disclosed in the centralized privacy policy under \"What we collect\" → error diagnostics and \"Third-party services\" → Sentry.

## Test plan
- [x] \`uv run ruff check .\` passes
- [x] \`uv run pytest\` passes (13/13)
- [ ] Post-merge: Cloud Run deploys → next production error captures with symbolicated stack trace AND IP/headers/user context
- [ ] Verify in Sentry UI that new events show \"User\" (IP-derived region) and \"Request\" (headers) sections populated

## Follow-up
**Phase 2, part 3 of 3** — matching \`sendDefaultPii: true\` flip in \`vagrant-story-web\` (\`src/lib/sentry.ts\`). Will be opened as a separate PR against vagrant-story-web after this one is deployed.