### PR TITLE
docs: link to live Swagger UI and drop stale data notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,45 +11,9 @@
 
 Public game data API for [Vagrant Story](https://en.wikipedia.org/wiki/Vagrant_Story). Part of the [criticalbit.gg](https://criticalbit.gg) gaming tools platform.
 
-No authentication required. Read-only. All data extracted from the game.
+No authentication required. Read-only.
 
-## Endpoints
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/weapons` | List all weapons (blades) |
-| GET | `/weapons/{id}` | Get weapon by ID |
-| GET | `/grips` | List all weapon grips |
-| GET | `/grips/{id}` | Get grip by ID |
-| GET | `/armor` | List all armor and shields |
-| GET | `/armor/{id}` | Get armor piece by ID |
-| GET | `/gems` | List all gems |
-| GET | `/gems/{id}` | Get gem by ID |
-| GET | `/materials` | List all crafting materials |
-| GET | `/materials/{id}` | Get material by ID |
-| GET | `/consumables` | List all consumable items |
-| GET | `/consumables/{id}` | Get consumable by ID |
-| GET | `/health` | Health check |
-
-### Query parameters
-
-- `offset` / `limit` — pagination (default: offset=0, limit=50)
-- `q` — search by name (e.g., `/weapons?q=katana`)
-- `blade_type` — filter weapons by type (`/weapons?blade_type=Sword`)
-- `type` — filter armor by type (`/armor?type=Shield`, `?type=Helm`, `?type=Body`, etc.)
-
-## Data
-
-Game data extracted from [korobetski/Vagrant-Story-Unity-Parser](https://github.com/korobetski/Vagrant-Story-Unity-Parser) (hardcoded C# databases). Descriptions are in French (from the French game version). English names cross-referenced with Data Crystal wiki.
-
-| Category | Count |
-|----------|-------|
-| Weapons (blades) | 90 |
-| Grips | 31 |
-| Armor + Shields | 111 |
-| Gems | 46 |
-| Materials | 7 |
-| Consumables | 29 |
+Live API docs (Swagger UI): [vagrant-story-api.criticalbit.gg/docs](https://vagrant-story-api.criticalbit.gg/docs)
 
 ## Development
 
@@ -72,16 +36,6 @@ uv run uvicorn app.main:app --reload --port 8002
 uv run ruff check .
 uv run ruff format .
 ```
-
-### Data extraction
-
-To re-extract game data from source:
-
-```bash
-python3 scripts/extract_data.py
-```
-
-Requires the [Vagrant-Story-Unity-Parser](https://github.com/korobetski/Vagrant-Story-Unity-Parser) repo cloned to `~/apps/criticalbit/data-extraction/`.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Replace the hand-maintained Endpoints table (which was incomplete and would drift) with a link to the live Swagger UI at https://vagrant-story-api.criticalbit.gg/docs — the FastAPI-generated spec is the canonical reference
- Remove the Data section that described an obsolete C# parser pipeline; data is now extracted in-house in English and the old description was actively misleading
- Keep dev commands and license

## Test plan
- [x] Render README locally and confirm it reads cleanly
- [x] Confirm Swagger link resolves