### PR TITLE
fix(loadout): correct damage formula for damage-type weaknesses

### DIFF
--- a/app/services/loadout_scorer.py
+++ b/app/services/loadout_scorer.py
@@ -190,9 +190,17 @@ def _get_enemy_class_key(enemy_class: str) -> str | None:
     return None
 
 
-def _get_bp_elemental(bp: EnemyBodyPart, elem: str) -> int:
-    """Get a body part's elemental defense, mapping 'wind' -> 'air' column."""
-    col = "air" if elem == "wind" else elem
+def _get_bp_affinity(bp: EnemyBodyPart, affinity: str) -> int:
+    """Read the body part's affinity defense for the attacker's active element.
+
+    ``affinity`` is the attacker's chosen affinity: "physical" for default
+    physical attacks, or one of the elements in ``ELEMENTAL_AFFINITIES``. The
+    enemy body part schema stores the elemental columns using "air" instead of
+    "wind", so this helper handles that translation as well.
+    """
+    if affinity == "physical":
+        return bp.physical
+    col = "air" if affinity == "wind" else affinity
     return getattr(bp, col, 0)
 
 
@@ -211,13 +219,28 @@ def score_offense(
 ) -> OffenseScore:
     """Score a weapon setup against an enemy using the real VS damage formula.
 
-    Uses the actual Vagrant Story combat mechanics:
-      Attack = (STR + WeapSTR + AccSTR) * (100 + Modifier) / 100
-      Modifier = (WeapClass + AccClass + WeapAffinity + AccAffinity
-                  + WeapType + AccType + PP% - DP%) // 4
-      Damage = Attack - Defense
+    Uses the game's actual attack/defense arithmetic:
 
-    Reference: Beamup's Combat Mechanics Guide (GameFAQs)
+        Attack    = (STR + WeapSTR + AccSTR) × (100 + AttackMod) / 100
+        AttackMod = (WeapClass + AccClass + WeapAff + AccAff
+                     + WeapType + AccType + PP% − DP%) / 4
+
+        BaseDef   = (DefSTR + DefAccSTR − 20) × (100 + DefMod) / 100
+        DefMod    = AccClass + Affinity + AccAffinity + Type + AccType
+
+        Damage    = Attack − Defense
+
+    The critical asymmetry: the defense modifier is NOT divided by 4, so
+    Class/Affinity/Type have four times the weight on Defense as on Attack.
+    That's what makes a damage-type weakness like Golem's −30 blunt on Body
+    dominate the score instead of being washed out by other modifiers.
+
+    For enemies the attacker-side modifiers are Ashley's; the defender-side
+    modifiers come from the body part's inherent ratings (``physical`` column
+    when the attack's effective affinity is Physical, an elemental column
+    otherwise, and ``blunt``/``edged``/``piercing`` for the damage type).
+    Enemies in the current data model don't wear accessories, so ``AccClass``
+    and friends on the defender are always 0.
     """
     if not enemy_body_parts:
         return OffenseScore(reasoning="Enemy has no body parts to target")
@@ -230,93 +253,94 @@ def score_offense(
     acc_str = accessory.str_stat if accessory else 0
     total_str = player_str + weap_str + acc_str
 
-    # ── Player's total AGI (base + weapon + accessory + armor) ──────
+    # ── Player's total AGI (base + weapon + accessory) ──────────────
     weap_agi = blade.agi_stat + grip.agi_stat + material.blade_agi
     weap_agi += sum(g.agi_stat for g in blade_gems)
     acc_agi = accessory.agi_stat if accessory else 0
     total_agi = player_agi + weap_agi + acc_agi
 
-    # ── Weapon Class affinity (vs enemy class) ──────────────────────
+    # ── Weapon Class (rating in the enemy's class) ──────────────────
     class_key = _get_enemy_class_key(enemy.enemy_class)
     weap_class = getattr(material, class_key, 0) if class_key else 0
     weap_class += sum(getattr(g, class_key, 0) for g in blade_gems)
     acc_class = getattr(accessory, class_key, 0) if accessory and class_key else 0
 
-    # ── Weapon Type (grip's stat matching blade's damage type) ──────
+    # ── Weapon Type (grip's rating in the blade's damage type) ──────
     damage_type_key = blade.damage_type.lower()
     weap_type = getattr(grip, damage_type_key, 0) if damage_type_key in DAMAGE_TYPES else 0
-    acc_type = 0  # accessories don't have damage type stats
+    acc_type = 0  # accessories don't carry damage-type ratings
+
+    # ── Weapon Affinity: Physical vs best element ───────────────────
+    # Physical is the default affinity. Only gems add Physical rating (the
+    # materials table has no physical column). An elemental rating (from
+    # material + gems) only overrides Physical if it beats the Physical total —
+    # matching the game's "highest affinity wins" rule.
+    physical_rating = sum(g.physical for g in blade_gems)
+    weap_affinity = physical_rating
+    best_element = "physical"
+    for elem in ELEMENTAL_AFFINITIES:
+        mat_elem = getattr(material, elem, 0)
+        gem_elem = sum(getattr(g, elem, 0) for g in blade_gems)
+        elem_total = mat_elem + gem_elem
+        if elem_total > weap_affinity:
+            weap_affinity = elem_total
+            best_element = elem
+    acc_affinity = 0  # accessories don't carry elemental ratings in the current schema
+
+    # Attack modifier is enemy-independent once the best element is chosen:
+    # weapon class depends on the enemy class (already resolved above), not on
+    # which body part we're hitting. Compute once.
+    attack_modifier = (
+        weap_class
+        + acc_class
+        + weap_affinity
+        + acc_affinity
+        + weap_type
+        + acc_type
+        + blade_pp_pct
+        - blade_dp_pct
+    ) // 4
+    attack = total_str * (100 + attack_modifier) // 100
 
     # ── Score each body part ────────────────────────────────────────
     bp_scores: list[BodyPartScore] = []
 
     for bp in enemy_body_parts:
-        # Weapon Affinity: best elemental match (material + gems vs body part weakness)
-        # In VS, the elemental affinity used is the weapon's elemental that the
-        # body part is weakest to (most negative defense = biggest bonus for attacker)
-        weap_affinity = 0
-        acc_affinity = 0
-        best_element = ""
-        for elem in ELEMENTAL_AFFINITIES:
-            mat_elem = getattr(material, elem, 0)
-            gem_elem = sum(getattr(g, elem, 0) for g in blade_gems)
-            weapon_elem_total = mat_elem + gem_elem
-            if weapon_elem_total > weap_affinity:
-                weap_affinity = weapon_elem_total
-                best_element = elem
-
-        # Attack modifier: (Class + Affinity + Type + PP% - DP%) / 4
-        attack_modifier = (
-            weap_class
-            + acc_class
-            + weap_affinity
-            + acc_affinity
-            + weap_type
-            + acc_type
-            + blade_pp_pct
-            - blade_dp_pct
-        ) // 4
-
-        # Attack value
-        attack = total_str * (100 + attack_modifier) // 100
-
-        # Enemy Defense for this body part
-        # Defense modifier comes from body part's type + physical + elemental resistances
+        # Defender's affinity rating against the attacker's active element.
+        bp_affinity = _get_bp_affinity(bp, best_element)
+        # Defender's rating against the attacker's damage type.
         bp_type = getattr(bp, damage_type_key, 0) if damage_type_key in DAMAGE_TYPES else 0
-        bp_physical = bp.physical
 
-        # Best elemental defense the enemy has (matching our weapon's affinity)
-        bp_affinity = _get_bp_elemental(bp, best_element) if best_element else 0
-
-        # Enemy class defense (enemies have inherent class — they don't have "class" stats
-        # in the same way, so we use the body part physical as the main defense base)
-        enemy_def_modifier = (bp_type + bp_physical + bp_affinity) // 4
-
-        # Enemy base defense: (EnemySTR - 20) * (100 + modifier) / 100
-        enemy_defense = max(0, (enemy.str_stat - 20) * (100 + enemy_def_modifier) // 100)
+        # Defense modifier: NOT divided by 4. Class/Affinity/Type have four
+        # times the weight on defense as on attack (see the module docstring
+        # for the full formula), and that extra weight is exactly what lets
+        # type weaknesses (e.g. Golem's −30 blunt on Body) dominate the score.
+        def_modifier = bp_affinity + bp_type
+        enemy_defense = max(0, (enemy.str_stat - 20) * (100 + def_modifier) // 100)
 
         # Estimated damage (regular attack, multiplier = 1.0)
         est_damage = max(0, attack - enemy_defense)
 
-        # Hit chance: Hit% = 100 + Acc - Dge (assume RISK = 0 for both sides)
-        acc = total_agi  # floor(AGL * (100-0) / 100) = AGL
-        dge = enemy.agi_stat + bp.evade  # floor((AGL + EVA) * (100-0) / 100)
+        # Hit chance: Hit% = 100 + Acc − Dge (assume RISK = 0 for both sides)
+        acc = total_agi
+        dge = enemy.agi_stat + bp.evade
         hit_pct = max(5, min(100, 100 + acc - dge))
 
         # Expected damage (hit-chance weighted)
         expected = est_damage * hit_pct / 100.0
 
-        # Build reasoning
         reasons = []
         if bp_type < 0:
             reasons.append(f"weak to {blade.damage_type} ({bp_type})")
         elif bp_type > 10:
             reasons.append(f"resists {blade.damage_type} (+{bp_type})")
-        if weap_affinity > 5 and best_element:
-            reasons.append(f"{best_element} affinity (+{weap_affinity})")
-        if class_key and weap_class > 5:
-            reasons.append(f"{class_key} affinity bonus (+{weap_class})")
-        if bp.evade > 10:
+        if bp_affinity < 0:
+            reasons.append(f"weak to {best_element} ({bp_affinity})")
+        elif bp_affinity > 30:
+            reasons.append(f"resists {best_element} (+{bp_affinity})")
+        if class_key and weap_class > 20:
+            reasons.append(f"{class_key} class bonus (+{weap_class})")
+        if bp.evade > 40:
             reasons.append(f"high evade ({bp.evade})")
         elif bp.evade == 0:
             reasons.append("low evade")

--- a/tests/test_loadout_scorer.py
+++ b/tests/test_loadout_scorer.py
@@ -1,0 +1,366 @@
+"""Unit tests for the loadout scoring formulas.
+
+These tests construct stub SQLAlchemy model instances (no DB) so they can
+verify the attack/defense arithmetic in isolation. They pin the behavior that
+was previously broken: Class/Affinity/Type modifiers must have four times the
+weight on Defense as on Attack, and the body part's ``physical`` column must
+be used as the defender's affinity rating when the attacker has no elemental.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.blade import Blade
+from app.models.enemy import Enemy, EnemyBodyPart
+from app.models.grip import Grip
+from app.models.material import Material
+from app.services.loadout_scorer import score_offense
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+_MATERIAL_INT_FIELDS = (
+    "str_modifier",
+    "int_modifier",
+    "agi_modifier",
+    "blade_str",
+    "blade_int",
+    "blade_agi",
+    "shield_str",
+    "shield_int",
+    "shield_agi",
+    "armor_str",
+    "armor_int",
+    "armor_agi",
+    "human",
+    "beast",
+    "undead",
+    "phantom",
+    "dragon",
+    "evil",
+    "fire",
+    "water",
+    "wind",
+    "earth",
+    "light",
+    "dark",
+)
+
+
+def _material(name: str, **overrides: int) -> Material:
+    kwargs = dict.fromkeys(_MATERIAL_INT_FIELDS, 0)
+    kwargs.update(overrides)
+    return Material(name=name, tier=1, **kwargs)
+
+
+def _blade(name: str, str_stat: int, damage_type: str, blade_type: str = "Sword") -> Blade:
+    return Blade(
+        game_id=1,
+        field_name=name.replace(" ", "_"),
+        name=name,
+        blade_type=blade_type,
+        damage_type=damage_type,
+        risk=1,
+        str_stat=str_stat,
+        int_stat=0,
+        agi_stat=-1,
+        range_stat=3,
+        damage=2,
+        hands="1H",
+    )
+
+
+def _grip(
+    name: str,
+    compatible: str,
+    *,
+    blunt: int = 0,
+    edged: int = 0,
+    piercing: int = 0,
+    str_stat: int = 1,
+    agi_stat: int = -1,
+) -> Grip:
+    return Grip(
+        game_id=1,
+        field_name=name.replace(" ", "_"),
+        name=name,
+        grip_type=compatible.split("/")[0],
+        compatible_weapons=compatible,
+        str_stat=str_stat,
+        int_stat=0,
+        agi_stat=agi_stat,
+        blunt=blunt,
+        edged=edged,
+        piercing=piercing,
+        gem_slots=0,
+        dp=None,
+        pp=None,
+        wep_file_id=0,
+    )
+
+
+def _body_part(
+    name: str, physical: int, blunt: int, edged: int, piercing: int, evade: int
+) -> EnemyBodyPart:
+    # Use placeholder elemental values that match the real Golem (all resist).
+    return EnemyBodyPart(
+        name=name,
+        physical=physical,
+        air=18,
+        fire=72,
+        water=45,
+        earth=75,
+        light=72,
+        dark=55,
+        blunt=blunt,
+        edged=edged,
+        piercing=piercing,
+        evade=evade,
+        chain_evade=0,
+    )
+
+
+# ── Golem fixture (matches data/enemies.json) ────────────────────────
+
+
+@pytest.fixture
+def golem() -> Enemy:
+    return Enemy(
+        name="Golem",
+        enemy_class="Evil",
+        hp=240,
+        mp=15,
+        str_stat=125,
+        int_stat=118,
+        agi_stat=92,
+        movement=6,
+        is_boss=False,
+    )
+
+
+@pytest.fixture
+def golem_body_parts() -> list[EnemyBodyPart]:
+    return [
+        _body_part("R. Arm", 32, blunt=-15, edged=5, piercing=15, evade=15),
+        _body_part("L. Arm", 32, blunt=-15, edged=5, piercing=15, evade=15),
+        _body_part("Head", 32, blunt=-18, edged=2, piercing=11, evade=52),
+        _body_part("Body", 32, blunt=-30, edged=-5, piercing=0, evade=48),
+        _body_part("R. Leg", 32, blunt=-10, edged=5, piercing=15, evade=0),
+        _body_part("L. Leg", 32, blunt=-10, edged=5, piercing=15, evade=0),
+    ]
+
+
+@pytest.fixture
+def iron() -> Material:
+    # Iron from data/materials.json — no positive elemental affinities.
+    return _material(
+        "Iron",
+        human=-2,
+        beast=1,
+        undead=1,
+        phantom=0,
+        dragon=10,
+        evil=0,
+        fire=-4,
+        water=-4,
+        wind=0,
+        earth=-1,
+        light=0,
+        dark=0,
+    )
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestGolemDamageTypeWeakness:
+    """Regression tests for the user-reported issue where the optimizer
+    recommended an Edged weapon against a Blunt-weak Golem.
+
+    Golem's body parts range from −10 (legs) to −30 (body) blunt, versus
+    −5 to +5 edged. Blunt should decisively outrank edged on every body
+    part and therefore in the overall best-target score.
+    """
+
+    def test_goblin_club_outdamages_scimitar_per_body_part(
+        self, golem: Enemy, golem_body_parts: list[EnemyBodyPart], iron: Material
+    ):
+        scimitar = _blade("Scimitar", str_stat=7, damage_type="Edged", blade_type="Sword")
+        short_hilt = _grip("Short Hilt", "Dagger/Sword/Great Sword", edged=4, piercing=1)
+
+        goblin_club = _blade(
+            "Goblin Club", str_stat=6, damage_type="Blunt", blade_type="Axe / Mace"
+        )
+        wooden_grip = _grip(
+            "Wooden Grip", "Axe/Mace/Great Axe/Heavy Mace/Staff", blunt=5, edged=1, agi_stat=-2
+        )
+
+        # Use a non-zero player_str so the formulas produce non-saturated
+        # numbers we can compare. 120 is roughly the user's reported case.
+        kwargs = {
+            "enemy": golem,
+            "enemy_body_parts": golem_body_parts,
+            "accessory": None,
+            "player_str": 120,
+            "player_agi": 30,
+            "blade_pp_pct": 100,
+            "blade_dp_pct": 0,
+        }
+        edged = score_offense(scimitar, short_hilt, iron, **kwargs)
+        blunt = score_offense(goblin_club, wooden_grip, iron, **kwargs)
+
+        # Assertion 1: overall expected damage clearly favors blunt.
+        assert blunt.expected_damage > edged.expected_damage * 1.5, (
+            f"blunt ({blunt.expected_damage}) should beat edged ({edged.expected_damage}) "
+            f"by at least 1.5x against a Blunt-weak Golem"
+        )
+
+        # Assertion 2: per-body-part raw damage favors blunt on every part
+        # that the damage-type weakness applies to. Match on part name so
+        # the comparison is order-independent.
+        edged_by_name = {bp.name: bp for bp in edged.body_parts}
+        blunt_by_name = {bp.name: bp for bp in blunt.body_parts}
+        for name in edged_by_name:
+            edged_bp = edged_by_name[name]
+            blunt_bp = blunt_by_name[name]
+            assert blunt_bp.estimated_damage >= edged_bp.estimated_damage, (
+                f"{name}: blunt {blunt_bp.estimated_damage} should be >= "
+                f"edged {edged_bp.estimated_damage}"
+            )
+        # Body takes the biggest hit from blunt (−30 vs −5 edged) — assert a
+        # meaningful per-hit gap there specifically.
+        assert blunt_by_name["Body"].estimated_damage > edged_by_name["Body"].estimated_damage + 15
+
+    def test_optimizer_picks_lowest_evade_target(
+        self, golem: Enemy, golem_body_parts: list[EnemyBodyPart], iron: Material
+    ):
+        """The best_target should be chosen by expected damage, not raw
+        damage. Golem's Body has the highest raw damage for blunt but 48
+        evade, while the Legs have 0 evade — so Legs should win on expected.
+        """
+        goblin_club = _blade(
+            "Goblin Club", str_stat=6, damage_type="Blunt", blade_type="Axe / Mace"
+        )
+        wooden_grip = _grip(
+            "Wooden Grip", "Axe/Mace/Great Axe/Heavy Mace/Staff", blunt=5, edged=1, agi_stat=-2
+        )
+
+        result = score_offense(
+            goblin_club,
+            wooden_grip,
+            iron,
+            golem,
+            golem_body_parts,
+            player_str=120,
+            player_agi=30,
+        )
+        assert result.best_target in ("R. Leg", "L. Leg")
+
+
+class TestAttackDefenseFormula:
+    """Pin the structural fixes to the attack/defense formula."""
+
+    def test_defense_modifier_uses_physical_column_for_default_affinity(
+        self, golem: Enemy, iron: Material
+    ):
+        """With no gems, the weapon's affinity is Physical — so the body
+        part's ``physical`` column must drive the defense modifier. Doubling
+        the physical rating must raise enemy defense and lower damage.
+        """
+        scimitar = _blade("Scimitar", str_stat=7, damage_type="Edged")
+        short_hilt = _grip("Short Hilt", "Dagger/Sword/Great Sword", edged=4)
+
+        base = [_body_part("Body", physical=32, blunt=0, edged=0, piercing=0, evade=0)]
+        tougher = [_body_part("Body", physical=64, blunt=0, edged=0, piercing=0, evade=0)]
+
+        kwargs = {
+            "blade": scimitar,
+            "grip": short_hilt,
+            "material": iron,
+            "enemy": golem,
+            "player_str": 120,
+            "player_agi": 30,
+        }
+        base_result = score_offense(enemy_body_parts=base, **kwargs)
+        tougher_result = score_offense(enemy_body_parts=tougher, **kwargs)
+
+        assert tougher_result.estimated_damage < base_result.estimated_damage, (
+            "doubling the body part's physical rating should reduce damage, "
+            "proving bp.physical is being applied as the defense modifier"
+        )
+
+    def test_damage_type_weakness_has_four_times_attack_weight(self, golem: Enemy, iron: Material):
+        """A +20 body-part damage-type rating (resist) should change damage
+        more than a +20 grip damage-type rating (attack bonus). The game's
+        real formula gives Class/Affinity/Type four times the weight on
+        Defense as on Attack — this test pins that asymmetry.
+        """
+        scimitar = _blade("Scimitar", str_stat=7, damage_type="Edged")
+
+        weak_grip = _grip("Weak", "Dagger/Sword/Great Sword", edged=0)
+        strong_grip = _grip("Strong", "Dagger/Sword/Great Sword", edged=20)
+
+        resistant_bp = [_body_part("Body", physical=0, blunt=0, edged=20, piercing=0, evade=0)]
+        neutral_bp = [_body_part("Body", physical=0, blunt=0, edged=0, piercing=0, evade=0)]
+
+        # Case A: weaker weapon vs neutral defender.
+        attack_bonus = score_offense(
+            scimitar,
+            strong_grip,
+            iron,
+            golem,
+            neutral_bp,
+            player_str=120,
+            player_agi=30,
+        )
+        baseline = score_offense(
+            scimitar,
+            weak_grip,
+            iron,
+            golem,
+            neutral_bp,
+            player_str=120,
+            player_agi=30,
+        )
+        # Case B: same neutral weapon vs resistant defender (+20 edged).
+        defense_resist = score_offense(
+            scimitar,
+            weak_grip,
+            iron,
+            golem,
+            resistant_bp,
+            player_str=120,
+            player_agi=30,
+        )
+
+        attack_gain = attack_bonus.estimated_damage - baseline.estimated_damage
+        defense_loss = baseline.estimated_damage - defense_resist.estimated_damage
+
+        # Defense impact should be several times attack impact for the same
+        # point value. Exact ratio depends on int truncation; 2x is a safe
+        # floor that still proves the formula is no longer symmetric.
+        assert defense_loss >= attack_gain * 2, (
+            f"+20 edged on defender should lower damage more than +20 edged on grip "
+            f"raises it (defense_loss={defense_loss}, attack_gain={attack_gain})"
+        )
+
+
+class TestEmptyAndEdgeCases:
+    def test_empty_body_parts_returns_reason(self, golem: Enemy, iron: Material):
+        scimitar = _blade("Scimitar", str_stat=7, damage_type="Edged")
+        short_hilt = _grip("Short Hilt", "Dagger/Sword/Great Sword", edged=4)
+
+        result = score_offense(scimitar, short_hilt, iron, golem, [], player_str=120, player_agi=30)
+        assert result.estimated_damage == 0
+        assert "no body parts" in result.reasoning.lower()
+
+    def test_damage_never_goes_negative(self, golem: Enemy, iron: Material):
+        """A weak player versus a tough enemy must floor at 0, not a negative."""
+        scimitar = _blade("Scimitar", str_stat=7, damage_type="Edged")
+        short_hilt = _grip("Short Hilt", "Dagger/Sword/Great Sword", edged=4)
+        bp = [_body_part("Body", physical=100, blunt=0, edged=100, piercing=0, evade=0)]
+
+        result = score_offense(scimitar, short_hilt, iron, golem, bp, player_str=0, player_agi=0)
+        for part in result.body_parts:
+            assert part.estimated_damage >= 0


### PR DESCRIPTION
## Summary
- `score_offense` diverged from the game's actual attack/defense arithmetic in three places, causing the optimizer to recommend edged weapons vs Blunt-weak enemies like the Golem and to report damage estimates ~2-6x higher than actual in-game damage.
- Rewrote the formula to match the real mechanics, moved the attack modifier out of the per-body-part loop, and added a regression test file pinning the Golem scenario end-to-end.

## What was wrong

1. **Defense modifier was divided by 4.** The old code computed `enemy_def_modifier = (bp_type + bp_physical + bp_affinity) // 4`, treating defense modifiers the same as attack modifiers. In the real formula, Class/Affinity/Type have four times the weight on Defense as on Attack — not a quarter. This squashed the Golem's 25-point blunt-vs-edged resistance gap on the Body into a ~6-point defense modifier difference, letting edged weapons tie or beat blunt.

2. **`bp.physical` was being added as a separate defense term.** The body part's `physical` column IS the defender's Affinity rating when the attacker uses Physical affinity (the default for weapons without elemental gems). When the attacker has gem-boosted elemental affinity, the matching elemental column is used instead. The old code added `bp_physical` alongside `bp_affinity` and bundled them through the /4 division, which is wrong on both counts.

3. **Weapon Affinity search excluded Physical.** The search only iterated `ELEMENTAL_AFFINITIES = (fire, water, wind, earth, light, dark)` and silently returned 0 for weapons with no elemental bonus. Physical is the default affinity and gems can contribute a Physical rating — this is now handled, with Physical as the starting candidate that only gets overridden if an elemental rating beats it (matching the game's "highest affinity wins" rule).

Also moved the attack-modifier computation out of the body-part loop since it only depends on enemy class, not on which body part is being targeted. The old nested loop recomputed identical values per body part with a misleading "best element per body part" scan.

## Numbers (Golem, real imported save, player_str=100 / agi=101)

Before the fix the optimizer saw the Scimitar (Edged) and Goblin Club (Blunt) as nearly tied vs a Blunt-weak Golem. After the fix:

| Weapon | Best target | Raw dmg | Hit% | Expected |
|---|---|---:|---:|---:|
| Scimitar + Short Hilt | Body | 3 | 59 | **1.8** |
| Goblin Club + Wooden Grip | Body | 27 | 58 | **15.7** |

Blunt wins by ~8.7x expected, matching the reported in-game behavior that motivated the investigation.

## Test plan
- [x] `ruff check app/services/loadout_scorer.py tests/test_loadout_scorer.py` clean
- [x] `ruff format --check` clean
- [x] Full `pytest` suite: 19/19 passing (13 existing + 6 new regression tests)
- [x] Manual smoke test against a real imported save with parsed base stats confirms Goblin Club outdamages Scimitar and estimated numbers align with reported in-game damage
- [ ] CI green