### PR TITLE
feat(api): launch guardrails — v1 dual-mount, real rate limits, security.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,8 @@ EXPOSE 8000
 ARG COMMIT_SHA=unknown
 ENV SENTRY_RELEASE=$COMMIT_SHA
 
-CMD [".venv/bin/uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# --proxy-headers + --forwarded-allow-ips=* makes uvicorn trust X-Forwarded-For
+# from Cloud Run's frontend so request.client.host is the real client IP.
+# Safe because Cloud Run guarantees requests only arrive via Google's frontend;
+# external clients cannot bypass it to forge the header.
+CMD [".venv/bin/uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips=*"]

--- a/app/main.py
+++ b/app/main.py
@@ -4,9 +4,11 @@ import uuid
 import structlog
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import PlainTextResponse
 from scalar_fastapi import get_scalar_api_reference
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
 from app.config import settings
 from app.logging import setup_logging
@@ -61,6 +63,10 @@ app.add_middleware(
 
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+# SlowAPIMiddleware is what actually enforces the Limiter's default_limits
+# against every route. Without it, only routes with an explicit
+# @limiter.limit(...) decorator would be rate-limited.
+app.add_middleware(SlowAPIMiddleware)
 
 
 MAX_REQUEST_BODY_SIZE = 1_048_576  # 1 MB
@@ -110,30 +116,40 @@ async def request_logging_middleware(request: Request, call_next) -> Response:
     return response
 
 
-app.include_router(blades_router)
-app.include_router(grips_router)
-app.include_router(armor_router)
-app.include_router(gems_router)
-app.include_router(materials_router)
-app.include_router(consumables_router)
-app.include_router(break_arts_router)
-app.include_router(battle_abilities_router)
-app.include_router(sigils_router)
-app.include_router(spells_router)
-app.include_router(keys_router)
-app.include_router(grimoires_router)
-app.include_router(workshops_router)
-app.include_router(chests_router)
-app.include_router(crafting_router)
-app.include_router(characters_router)
-app.include_router(enemies_router)
-app.include_router(titles_router)
-app.include_router(rankings_router)
-app.include_router(areas_router)
-app.include_router(rooms_router)
-app.include_router(drops_router)
-app.include_router(loadout_router)
-app.include_router(user_router)
+# Canonical public API lives under /v1. During the frontend migration we also
+# mount everything at the root so existing unversioned clients keep working.
+# The unversioned mount is scheduled for removal once vagrant-story-web is on /v1.
+ROUTERS = (
+    blades_router,
+    grips_router,
+    armor_router,
+    gems_router,
+    materials_router,
+    consumables_router,
+    break_arts_router,
+    battle_abilities_router,
+    sigils_router,
+    spells_router,
+    keys_router,
+    grimoires_router,
+    workshops_router,
+    chests_router,
+    crafting_router,
+    characters_router,
+    enemies_router,
+    titles_router,
+    rankings_router,
+    areas_router,
+    rooms_router,
+    drops_router,
+    loadout_router,
+    user_router,
+)
+
+for router in ROUTERS:
+    app.include_router(router, prefix="/v1")
+for router in ROUTERS:
+    app.include_router(router)
 
 
 @app.get("/docs", include_in_schema=False)
@@ -145,10 +161,27 @@ async def scalar_docs():
 
 
 @app.get("/")
+@limiter.exempt
 async def root():
     return {"status": "ok", "service": "vagrant-story-api"}
 
 
 @app.get("/health")
+@limiter.exempt
 async def health_check():
     return {"status": "healthy"}
+
+
+# Per https://securitytxt.org/ — security researchers and automated scanners
+# look for this file to find an abuse contact. Bump Expires before 2027-04-15.
+SECURITY_TXT = """\
+Contact: mailto:security@criticalbit.gg
+Expires: 2027-04-15T00:00:00.000Z
+Preferred-Languages: en
+"""
+
+
+@app.get("/.well-known/security.txt", include_in_schema=False)
+@limiter.exempt
+async def security_txt() -> PlainTextResponse:
+    return PlainTextResponse(SECURITY_TXT)

--- a/app/rate_limit.py
+++ b/app/rate_limit.py
@@ -1,4 +1,7 @@
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address)
+# Global default applies to every route that doesn't set its own @limiter.limit.
+# Keyed on the real client IP — this requires uvicorn to be run with
+# --proxy-headers so X-Forwarded-For is trusted behind Cloud Run's frontend.
+limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,25 @@ class TestHealth:
         assert resp.json()["service"] == "vagrant-story-api"
 
 
+class TestLaunchGuardrails:
+    async def test_security_txt(self, client: AsyncClient):
+        resp = await client.get("/.well-known/security.txt")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/plain")
+        body = resp.text
+        assert "Contact: mailto:security@criticalbit.gg" in body
+        assert "Expires:" in body
+
+    async def test_v1_mount_matches_unversioned(self, client: AsyncClient):
+        # Dual-mount: every router is exposed at both /x and /v1/x during the
+        # frontend migration. Both must return identical payloads.
+        unversioned = await client.get("/blades")
+        v1 = await client.get("/v1/blades")
+        assert unversioned.status_code == 200
+        assert v1.status_code == 200
+        assert unversioned.json() == v1.json()
+
+
 class TestBlades:
     async def test_list_empty(self, client: AsyncClient):
         resp = await client.get("/blades")


### PR DESCRIPTION
## Summary

Four related launch-prep fixes, all bundled because they're tightly coupled: the rate-limit fix depends on the proxy-header fix, and the v1 mount is the shape change everything else sits inside.

### 1. Trust `X-Forwarded-For` behind Cloud Run

`Dockerfile` CMD now passes `--proxy-headers --forwarded-allow-ips=*` to uvicorn. Without this, `request.client.host` resolves to Cloud Run's internal frontend IP — meaning `slowapi.util.get_remote_address` was collapsing every request into a single global bucket. The loadout route's existing `@limiter.limit(\"10/minute\")` was therefore a **global 10/min shared across the entire internet**, not per-user as intended.

`--forwarded-allow-ips=*` is safe on Cloud Run specifically because Google's frontend is the only path into the container — external clients cannot forge `X-Forwarded-For` and reach us directly.

### 2. Actually enforce default rate limits

- `app/rate_limit.py`: `Limiter(default_limits=[\"60/minute\"])`
- `app/main.py`: installs `SlowAPIMiddleware`

**Why the middleware matters**: `default_limits` on the `Limiter` is dormant without `SlowAPIMiddleware` — it's only applied by the middleware on routes that don't have their own `@limiter.limit` decorator. Until this PR, 24 of 25 routers had no limit at all; only `loadout` had one.

The explicit per-route `@limiter.limit(\"10/minute\")` on loadout still works; it overrides the 60/min default on that one endpoint.

### 3. Dual-mount all routers under `/v1`

Routers refactored into a `ROUTERS` tuple and mounted twice:

```python
for router in ROUTERS:
    app.include_router(router, prefix=\"/v1\")   # canonical public API
for router in ROUTERS:
    app.include_router(router)                  # transitional unversioned
```

The unversioned mount exists to keep the vagrant-story-web frontend working until it migrates to `/v1` (tracked as a separate PR on the web repo). Once the frontend is on `/v1`, the unversioned loop can be deleted.

**Why bundle this now?** Once the API launches publicly, path shape is load-bearing. Fixing versioning after external consumers exist means a breaking change + deprecation cycle. Adding `/v1` while the frontend is the sole consumer costs a few lines of code.

### 4. Add `/.well-known/security.txt`

Standard contact file per securitytxt.org so researchers and automated scanners can find a vulnerability-reporting address. Uses `security@criticalbit.gg` matching the existing `privacy@criticalbit.gg` pattern set up in the criticalbit infra.

**Action required**: an email routing rule for `security@criticalbit.gg` needs to be added in Cloudflare (same process as privacy@). Tracked separately.

Expires is set to 2027-04-15 and must be bumped before then.

### Rate limit exemptions

`/`, `/health`, and `/.well-known/security.txt` are marked `@limiter.exempt`. Health checks need to never be rate-limited (Cloud Run health-checks the service continuously) and security.txt can be hit by many scanners at once.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format .` — no changes
- [x] `uv run pytest` — 21/21 pass (up from 19; two new tests added)
  - [x] `test_security_txt` — security.txt file exists with expected contact and expires lines
  - [x] `test_v1_mount_matches_unversioned` — `/v1/blades` and `/blades` return identical payloads
- [ ] Post-deploy: `curl https://vagrant-story-api.criticalbit.gg/.well-known/security.txt` returns the file
- [ ] Post-deploy: `curl https://vagrant-story-api.criticalbit.gg/v1/blades` returns the same data as `/blades`
- [ ] Post-deploy: repeated requests eventually return 429 (rate limit enforced)

## Follow-ups

- **Frontend /v1 migration** — separate PR on vagrant-story-web
- **Cloudflare email routing for `security@criticalbit.gg`** — mirror of the existing `privacy@` rule
- **Remove the unversioned mount** — once the frontend is fully on `/v1`