### PR TITLE
chore(api): remove transitional unversioned mount

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -116,9 +116,9 @@ async def request_logging_middleware(request: Request, call_next) -> Response:
     return response
 
 
-# Canonical public API lives under /v1. During the frontend migration we also
-# mount everything at the root so existing unversioned clients keep working.
-# The unversioned mount is scheduled for removal once vagrant-story-web is on /v1.
+# Public API lives under /v1. Non-versioned app-level routes (/, /health,
+# /docs, /.well-known/security.txt) stay at the root since they're
+# infrastructure, not part of the versioned data contract.
 ROUTERS = (
     blades_router,
     grips_router,
@@ -148,8 +148,6 @@ ROUTERS = (
 
 for router in ROUTERS:
     app.include_router(router, prefix="/v1")
-for router in ROUTERS:
-    app.include_router(router)
 
 
 @app.get("/docs", include_in_schema=False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,19 +27,17 @@ class TestLaunchGuardrails:
         assert "Contact: mailto:security@criticalbit.gg" in body
         assert "Expires:" in body
 
-    async def test_v1_mount_matches_unversioned(self, client: AsyncClient):
-        # Dual-mount: every router is exposed at both /x and /v1/x during the
-        # frontend migration. Both must return identical payloads.
-        unversioned = await client.get("/blades")
-        v1 = await client.get("/v1/blades")
-        assert unversioned.status_code == 200
-        assert v1.status_code == 200
-        assert unversioned.json() == v1.json()
+    async def test_unversioned_routes_removed(self, client: AsyncClient):
+        # The transitional unversioned mount was removed once the
+        # vagrant-story-web frontend finished migrating to /v1.
+        # Old paths should now 404; /v1 is the only public data path.
+        assert (await client.get("/v1/blades")).status_code == 200
+        assert (await client.get("/blades")).status_code == 404
 
 
 class TestBlades:
     async def test_list_empty(self, client: AsyncClient):
-        resp = await client.get("/blades")
+        resp = await client.get("/v1/blades")
         assert resp.status_code == 200
         assert resp.json() == []
 
@@ -61,7 +59,7 @@ class TestBlades:
         session.add(blade)
         await session.commit()
 
-        resp = await client.get("/blades")
+        resp = await client.get("/v1/blades")
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
@@ -82,12 +80,12 @@ class TestBlades:
         session.add(blade)
         await session.commit()
 
-        resp = await client.get(f"/blades/{blade.id}")
+        resp = await client.get(f"/v1/blades/{blade.id}")
         assert resp.status_code == 200
         assert resp.json()["name"] == "Katana"
 
     async def test_not_found(self, client: AsyncClient):
-        resp = await client.get("/blades/999")
+        resp = await client.get("/v1/blades/999")
         assert resp.status_code == 404
 
     async def test_search(self, client: AsyncClient, session: AsyncSession):
@@ -111,14 +109,14 @@ class TestBlades:
         )
         await session.commit()
 
-        resp = await client.get("/blades?q=clay")
+        resp = await client.get("/v1/blades?q=clay")
         assert len(resp.json()) == 1
         assert resp.json()[0]["name"] == "Claymore"
 
 
 class TestEnemies:
     async def test_list_empty(self, client: AsyncClient):
-        resp = await client.get("/enemies")
+        resp = await client.get("/v1/enemies")
         assert resp.status_code == 200
         assert resp.json() == []
 
@@ -135,7 +133,7 @@ class TestEnemies:
         session.add(enemy)
         await session.commit()
 
-        resp = await client.get("/enemies")
+        resp = await client.get("/v1/enemies")
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
@@ -175,7 +173,7 @@ class TestEnemies:
         session.add(bp)
         await session.commit()
 
-        resp = await client.get(f"/enemies/{enemy.id}")
+        resp = await client.get(f"/v1/enemies/{enemy.id}")
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "Bat"
@@ -185,7 +183,7 @@ class TestEnemies:
         assert data["body_parts"][0]["air"] == 25
 
     async def test_not_found(self, client: AsyncClient):
-        resp = await client.get("/enemies/999")
+        resp = await client.get("/v1/enemies/999")
         assert resp.status_code == 404
 
     async def test_search(self, client: AsyncClient, session: AsyncSession):
@@ -207,7 +205,7 @@ class TestEnemies:
         )
         await session.commit()
 
-        resp = await client.get("/enemies?q=bat")
+        resp = await client.get("/v1/enemies?q=bat")
         assert len(resp.json()) == 1
         assert resp.json()[0]["name"] == "Bat"
 
@@ -217,7 +215,7 @@ class TestMaterials:
         session.add(Material(name="Iron", tier=4, str_modifier=1, int_modifier=1, agi_modifier=-2))
         await session.commit()
 
-        resp = await client.get("/materials")
+        resp = await client.get("/v1/materials")
         assert resp.status_code == 200
         assert len(resp.json()) == 1
         assert resp.json()[0]["name"] == "Iron"


### PR DESCRIPTION
## Summary

Follow-up cleanup to #73. The dual-mount was retained only so the vagrant-story-web frontend could migrate to \`/v1\` without a coordinated deploy. That migration shipped in [ag-tech-group/vagrant-story-web#149](https://github.com/ag-tech-group/vagrant-story-web/pull/149) and the frontend now talks exclusively to \`/v1\`. There are no other known API consumers, so the unversioned mount is dead code.

## Changes

- **app/main.py**: delete the second \`for router in ROUTERS: app.include_router(router)\` loop
- **tests/test_api.py**: update all paths to \`/v1\` prefix; replace \`test_v1_mount_matches_unversioned\` with \`test_unversioned_routes_removed\` which asserts \`/v1/blades → 200\` AND \`/blades → 404\`. The 404 assertion is important — without it the cleanup could "pass" by accident even if the deletion were reverted.

## What stays at the root

Non-versioned routes unaffected — these are infrastructure rather than versioned data contracts:
- \`/\` (landing)
- \`/health\` (Cloud Run health check target)
- \`/docs\` (Scalar API reference)
- \`/openapi.json\` (OpenAPI spec)
- \`/.well-known/security.txt\`

## Test plan

- [x] \`uv run ruff check .\` → clean
- [x] \`uv run ruff format .\` → no changes
- [x] \`uv run pytest\` → 21/21 pass (including the new 404 assertion)
- [ ] Post-deploy: \`curl https://vagrant-story-api.criticalbit.gg/blades\` returns 404
- [ ] Post-deploy: \`curl https://vagrant-story-api.criticalbit.gg/v1/blades?limit=1\` returns 200
- [ ] Post-deploy: frontend still renders (the sitemap generator and runtime client both already target \`/v1\`)