### PR TITLE
fix(cache): mark auth-required responses no-store instead of 1h public

### DIFF
--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -23,6 +23,12 @@ def _decode_kwargs() -> dict:
 
 async def get_current_user(request: Request) -> str:
     """Extract and verify the JWT from the app_access cookie, returning the user_id."""
+    # Flag the request so the cache-header middleware emits `Cache-Control:
+    # no-store` for any endpoint that depends on auth — including 401s, which
+    # otherwise risk being stored by a heuristic cache. Set before any raise
+    # so failures are tagged too.
+    request.state.auth_required = True
+
     token = request.cookies.get("app_access")
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")

--- a/app/main.py
+++ b/app/main.py
@@ -83,8 +83,18 @@ async def limit_request_size(request: Request, call_next) -> Response:
 @app.middleware("http")
 async def add_cache_headers(request: Request, call_next) -> Response:
     response = await call_next(request)
-    if request.url.path.startswith("/user/"):
+    # Auth-required responses must never be stored by browsers or shared
+    # caches — the flag is set by `get_current_user` so any endpoint that
+    # depends on it is covered automatically. `Vary: Cookie` is added as
+    # defense in depth against any cache that ignores `no-store`.
+    if getattr(request.state, "auth_required", False):
         response.headers["Cache-Control"] = "no-store"
+        existing_vary = [
+            v.strip() for v in response.headers.get("Vary", "").split(",") if v.strip()
+        ]
+        if "Cookie" not in existing_vary:
+            existing_vary.append("Cookie")
+        response.headers["Vary"] = ", ".join(existing_vary)
     elif request.method == "GET" and response.status_code == 200:
         response.headers["Cache-Control"] = "public, max-age=3600"
     return response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,6 +35,30 @@ class TestLaunchGuardrails:
         assert (await client.get("/blades")).status_code == 404
 
 
+class TestCacheHeaders:
+    # Regression coverage for the /v1 migration that inadvertently made
+    # authenticated endpoints publicly cacheable for an hour because the
+    # middleware's path prefix check matched pre-v1 routes only.
+    async def test_public_endpoints_are_cacheable(self, client: AsyncClient):
+        resp = await client.get("/v1/blades")
+        assert resp.status_code == 200
+        assert resp.headers["cache-control"] == "public, max-age=3600"
+
+    async def test_auth_required_endpoints_are_no_store(self, client: AsyncClient):
+        # Unauthenticated — the dependency raises 401, but the auth-required
+        # flag is set before the raise so the response is still marked no-store.
+        resp = await client.get("/v1/user/inventories")
+        assert resp.status_code == 401
+        assert resp.headers["cache-control"] == "no-store"
+        assert "Cookie" in resp.headers["vary"]
+
+    async def test_loadout_endpoint_is_no_store(self, client: AsyncClient):
+        resp = await client.post("/v1/loadout", json={})
+        assert resp.status_code == 401
+        assert resp.headers["cache-control"] == "no-store"
+        assert "Cookie" in resp.headers["vary"]
+
+
 class TestBlades:
     async def test_list_empty(self, client: AsyncClient):
         resp = await client.get("/v1/blades")


### PR DESCRIPTION
## Summary

- The `/v1` path migration in #149 left the `Cache-Control` middleware's path prefix check (`startswith("/user/")`) pointing at pre-v1 routes, so authenticated endpoints silently fell into the public-cache branch — prod was emitting `Cache-Control: public, max-age=3600` on `GET /v1/user/inventories` and `/v1/loadout/*` with no `Vary: Cookie`.
- User-reported symptoms ("deleted inventories reappear on reload", "re-uploaded saves don't show", "re-delete returns 404"): the write path hits the backend correctly while the read path is served from the browser's HTTP cache for up to an hour. Cloud Logging confirmed zero `GET` requests reaching the API after the DELETE in the repro session — the browser cache was answering them.
- Fix couples the cache decision to the auth dependency itself: `get_current_user` sets `request.state.auth_required = True` (before any raise, so 401s are also flagged), and the cache middleware emits `Cache-Control: no-store` + `Vary: Cookie` whenever that flag is present. Any future auth-required route is covered automatically by depending on `get_current_user` — no prefix list to maintain.

## Test plan

- [x] `uv run pytest` — 24 passed, including new `TestCacheHeaders` class
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] Verified header on rebuilt local stack:
  - `GET /v1/blades` → `Cache-Control: public, max-age=3600`
  - `GET /v1/user/inventories` (unauthed 401) → `Cache-Control: no-store` + `Vary: Cookie`
- [ ] After deploy, verify prod `GET /v1/user/inventories` returns `Cache-Control: no-store` and a repro of the original delete→reload flow no longer sticks