### PR TITLE
fix(auth): read access JWT from criticalbit_access cookie

### DIFF
--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -22,14 +22,14 @@ def _decode_kwargs() -> dict:
 
 
 async def get_current_user(request: Request) -> str:
-    """Extract and verify the JWT from the app_access cookie, returning the user_id."""
+    """Extract and verify the JWT from the criticalbit_access cookie, returning the user_id."""
     # Flag the request so the cache-header middleware emits `Cache-Control:
     # no-store` for any endpoint that depends on auth — including 401s, which
     # otherwise risk being stored by a heuristic cache. Set before any raise
     # so failures are tagged too.
     request.state.auth_required = True
 
-    token = request.cookies.get("app_access")
+    token = request.cookies.get("criticalbit_access")
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,8 @@
+import time
+from unittest.mock import patch
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric import rsa
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -244,3 +249,36 @@ class TestMaterials:
         assert len(resp.json()) == 1
         assert resp.json()[0]["name"] == "Iron"
         assert resp.json()[0]["str_modifier"] == 1
+
+
+class TestAuthCookie:
+    # Locks the cookie-name contract with criticalbit-auth-api: that service sets
+    # the access JWT under `criticalbit_access`, this service must read the same
+    # name. A silent rename 401s every authenticated request across the frontend.
+    async def test_valid_cookie_authenticates(self, client: AsyncClient):
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        public_key = private_key.public_key()
+        token = pyjwt.encode(
+            {
+                "sub": "user-abc",
+                "aud": "fastapi-users:auth",
+                "exp": int(time.time()) + 300,
+            },
+            private_key,
+            algorithm="RS256",
+        )
+
+        async def fake_get_public_key(force_refresh: bool = False):
+            return public_key
+
+        client.cookies.set("criticalbit_access", token)
+        with patch("app.auth.dependencies.get_public_key", fake_get_public_key):
+            resp = await client.get("/v1/user/inventories")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_missing_cookie_returns_401(self, client: AsyncClient):
+        resp = await client.get("/v1/user/inventories")
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Not authenticated"


### PR DESCRIPTION
## Summary
- Rename the cookie this resource server reads from `app_access` to `criticalbit_access`, matching the service-scoped name now issued by [criticalbit-auth-api#24](https://github.com/ag-tech-group/criticalbit-auth-api/pull/24).
- Add `TestAuthCookie` wire-level coverage: mints an RS256 JWT with an ephemeral keypair, patches `get_public_key`, and asserts (a) a valid `criticalbit_access` cookie authenticates a request to `/v1/user/inventories`, and (b) no cookie returns 401. This locks the cross-service cookie-name contract so a future rename or typo fails CI instead of silently 401-ing every authenticated request.
- Hard cut — no dual-accept fallback. Deploy after the auth-api rename is live in the target environment, otherwise existing sessions will 401 until re-login.

## Scope of audit
The logout refresh-token revocation fix from the upstream PR does **not** apply here — this repo has no logout handler, no refresh-token decode, no `fastapi_users.jwt` import (it uses raw PyJWT), and no OAuth/CSRF cookies. This service is a pure resource server that verifies RS256 tokens via JWKS from `auth-api.criticalbit.gg`; it is not an auth provider. The only cross-repo change that lands here is the single cookie read.

## Test plan
- [x] `uv run pytest` — 26/26 pass locally
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] CI green
- [ ] Post-deploy: confirm `/v1/user/inventories` works from the frontend in the target env (only meaningful after auth-api#24 is deployed there)