### PR TITLE
docs(readme): document /v1, auth-gated routes, rate limits, security.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@
 [![CI](https://github.com/ag-tech-group/vagrant-story-api/actions/workflows/ci.yml/badge.svg)](https://github.com/ag-tech-group/vagrant-story-api/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-Public game data API for [Vagrant Story](https://en.wikipedia.org/wiki/Vagrant_Story). Part of the [criticalbit.gg](https://criticalbit.gg) gaming tools platform.
-
-No authentication required. Read-only.
+Game data API for [Vagrant Story](https://en.wikipedia.org/wiki/Vagrant_Story). Part of the [criticalbit.gg](https://criticalbit.gg) gaming tools platform. Pairs with [vagrant-story-web](../vagrant-story-web).
 
 Live API docs (Swagger UI): [vagrant-story-api.criticalbit.gg/docs](https://vagrant-story-api.criticalbit.gg/docs)
+
+## API surface
+
+- **All data routes are versioned under `/v1`** — `GET /v1/blades`, `GET /v1/enemies/{id}`, `GET /v1/drops?item=...`, etc. Infrastructure routes (`/`, `/health`, `/docs`, `/.well-known/security.txt`) stay unversioned.
+- **Game data is public and read-only** — no auth needed for blades, armor, gems, grips, materials, consumables, enemies, areas, rooms, chests, drops, spells, abilities, rankings, crafting, workshops, and the rest.
+- **Per-user routes require a CriticalBit account** — `/v1/user/inventories/*` (inventory CRUD plus PS1 memory-card save import) and `POST /v1/loadout` (equipment optimizer) authenticate via the `criticalbit_access` JWT cookie issued by [criticalbit-auth-api](../../criticalbit/criticalbit-auth-api), verified against its JWKS.
+- **Rate limited** — 60 requests/minute per client IP by default (some routes are exempt). Behind Cloud Run this relies on `--proxy-headers` so the client IP comes from `X-Forwarded-For`.
+- **`/.well-known/security.txt`** — RFC 9116 contact info for vulnerability reports.
 
 ## Development
 


### PR DESCRIPTION
The README still said "No authentication required. Read-only." — no longer true since the `loadout` and `user` routers landed. Replaced that with an **API surface** section:

- All data routes are versioned under `/v1`; infrastructure routes (`/`, `/health`, `/docs`, `/.well-known/security.txt`) stay unversioned.
- Game data is public and read-only.
- `/v1/user/inventories/*` (inventory CRUD + PS1 memory-card save import) and `POST /v1/loadout` require a CriticalBit account — they authenticate via the `criticalbit_access` JWT cookie, verified against criticalbit-auth-api's JWKS.
- 60 req/min/IP default rate limit (some routes exempt).
- `/.well-known/security.txt` for vulnerability reports.

Docs only — no code changes.